### PR TITLE
Potential fix for code scanning alert no. 10: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/backapp/internal/handler/auth_handler.go
+++ b/backapp/internal/handler/auth_handler.go
@@ -580,7 +580,7 @@ func generateStateOauthCookie(w http.ResponseWriter, r *http.Request) string {
 		Expires:  expiration,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   middleware.IsRequestSecure(r),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, &cookie)

--- a/backapp/tests/handler/auth_handler_test.go
+++ b/backapp/tests/handler/auth_handler_test.go
@@ -35,6 +35,35 @@ func TestAuthHandler_GoogleLogin(t *testing.T) {
 		assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 		assert.Equal(t, "http://localhost:5173/?error=line_inapp_browser_unsupported", w.Header().Get("Location"))
 	})
+
+	t.Run("sets oauth state cookie with secure attribute", func(t *testing.T) {
+		mockUserRepo := new(MockUserRepository)
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		authHandler := handler.NewAuthHandler(&config.Config{}, mockUserRepo, mockEventRepo, mockClassRepo)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/auth/google/login", nil)
+
+		authHandler.GoogleLogin(c)
+
+		assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+
+		var oauthStateCookie *http.Cookie
+		for _, cookie := range w.Result().Cookies() {
+			if cookie.Name == "oauthstate" {
+				oauthStateCookie = cookie
+				break
+			}
+		}
+
+		if assert.NotNil(t, oauthStateCookie) {
+			assert.True(t, oauthStateCookie.Secure)
+			assert.True(t, oauthStateCookie.HttpOnly)
+			assert.Equal(t, http.SameSiteLaxMode, oauthStateCookie.SameSite)
+		}
+	})
 }
 
 func TestAuthHandler_UpdateUserClassRepByRoot(t *testing.T) {

--- a/frontapp/e2e/student-issueqr-code.spec.js
+++ b/frontapp/e2e/student-issueqr-code.spec.js
@@ -24,7 +24,7 @@ test.describe('QRコード発行 (student)', () => {
       sport_id: 1
     });
 
-    await expect(page.getByRole('heading', { name: 'QRコード' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'QRコード', exact: true })).toBeVisible();
     await expect(page.getByAltText('QR Code')).toBeVisible();
     await expect(page.getByText('競技: バスケットボール')).toBeVisible();
     await expect(page.getByText('有効期限まで残り時間:')).toBeVisible();


### PR DESCRIPTION
Potential fix for [https://github.com/snct-SportEase/web/security/code-scanning/10](https://github.com/snct-SportEase/web/security/code-scanning/10)

Set the cookie’s `Secure` attribute to `true` explicitly and unconditionally in `generateStateOauthCookie` in `backapp/internal/handler/auth_handler.go`.

Best fix (without changing existing functionality beyond security hardening):
- In the cookie literal inside `generateStateOauthCookie`, replace:
  - `Secure: middleware.IsRequestSecure(r),`
  with:
  - `Secure: true,`
- Keep `HttpOnly` and `SameSite` as-is.

This guarantees the cookie is only transmitted over HTTPS and satisfies CodeQL’s requirement that Secure is always true. No new methods or imports are required; in fact, this change removes usage of `middleware` in this shown snippet, but we should not alter imports unless necessary beyond the provided region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
