### PR TITLE
Fix secure session cookie attributes

### DIFF
--- a/backapp/internal/handler/auth_handler.go
+++ b/backapp/internal/handler/auth_handler.go
@@ -156,21 +156,11 @@ func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 	sessionToken := uuid.New().String()
 	middleware.CreateSession(sessionToken, user.ID)
 
-	isSecure := middleware.IsRequestSecure(c.Request)
-
 	// Set session cookie
-	http.SetCookie(c.Writer, &http.Cookie{
-		Name:     "session_token",
-		Value:    sessionToken,
-		Expires:  time.Now().Add(24 * time.Hour),
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   isSecure,
-		SameSite: http.SameSiteLaxMode,
-	})
+	setSessionTokenCookie(c.Writer, sessionToken, time.Now().Add(24*time.Hour))
 
 	// Add a debug log to verify cookie flags
-	log.Printf("[auth] Session created for user %s, secure=%v, origin=%s", user.Email, isSecure, c.Request.RemoteAddr)
+	log.Printf("[auth] Session created for user %s, secure=true, origin=%s", user.Email, c.Request.RemoteAddr)
 
 	c.Redirect(http.StatusTemporaryRedirect, strings.TrimSuffix(h.cfg.FrontendURL, "/")+"/dashboard")
 }
@@ -280,15 +270,7 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	middleware.DeleteSession(cookie)
 
-	http.SetCookie(c.Writer, &http.Cookie{
-		Name:     "session_token",
-		Value:    "",
-		Expires:  time.Now().Add(-1 * time.Hour),
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   middleware.IsRequestSecure(c.Request),
-		SameSite: http.SameSiteLaxMode,
-	})
+	setSessionTokenCookie(c.Writer, "", time.Now().Add(-1*time.Hour))
 
 	c.JSON(http.StatusOK, gin.H{"message": "logout successful"})
 }
@@ -586,6 +568,18 @@ func generateStateOauthCookie(w http.ResponseWriter, r *http.Request) string {
 	http.SetCookie(w, &cookie)
 
 	return state
+}
+
+func setSessionTokenCookie(w http.ResponseWriter, value string, expiration time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_token",
+		Value:    value,
+		Expires:  expiration,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }
 
 func isLINEInAppBrowser(userAgent string) bool {

--- a/backapp/internal/handler/auth_handler_test.go
+++ b/backapp/internal/handler/auth_handler_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSetSessionTokenCookieUsesSecureAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		expiration time.Time
+	}{
+		{
+			name:       "creates session cookie",
+			value:      "session-token",
+			expiration: time.Now().Add(24 * time.Hour),
+		},
+		{
+			name:       "clears session cookie",
+			value:      "",
+			expiration: time.Now().Add(-1 * time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			setSessionTokenCookie(w, tt.value, tt.expiration)
+
+			cookies := w.Result().Cookies()
+			if len(cookies) != 1 {
+				t.Fatalf("expected exactly one cookie, got %d", len(cookies))
+			}
+
+			cookie := cookies[0]
+			if cookie.Name != "session_token" {
+				t.Fatalf("expected session_token cookie, got %q", cookie.Name)
+			}
+			if cookie.Value != tt.value {
+				t.Fatalf("expected cookie value %q, got %q", tt.value, cookie.Value)
+			}
+			if cookie.Path != "/" {
+				t.Fatalf("expected cookie path /, got %q", cookie.Path)
+			}
+			if !cookie.HttpOnly {
+				t.Fatal("expected cookie to be HttpOnly")
+			}
+			if !cookie.Secure {
+				t.Fatal("expected cookie to be Secure")
+			}
+			if cookie.SameSite != http.SameSiteLaxMode {
+				t.Fatalf("expected SameSite=Lax, got %v", cookie.SameSite)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- set `session_token` cookies with `Secure: true` unconditionally
- share the session cookie attributes between login and logout
- add coverage for secure session cookie attributes when creating and clearing the cookie

## Why

Fixes #185.

CodeQL reports `go/cookie-secure-not-set` for the session cookie set during Google callback and logout. The previous implementation made `Secure` depend on request/proxy state, which leaves the cookie without the Secure attribute on HTTP requests.

## Validation

- `go test ./...`
