### PR TITLE
Add explicit workflow permissions

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - ci/auto-test
 
+permissions:
+  contents: read
+
 jobs:
   backend-test:
     name: Backend Go Tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   backend-test:
     name: Backend Go Tests
@@ -107,6 +110,7 @@ jobs:
     name: Deploy to Server
     needs: [backend-test, frontend-test]
     runs-on: ubuntu-latest
+    permissions: {}
 
     steps:
       - name: Deploy using SSH

--- a/.github/workflows/key.yml
+++ b/.github/workflows/key.yml
@@ -19,6 +19,8 @@ name: Recover SSH Key for Local Access
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   recover-key:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-compose-recreate.yml
+++ b/.github/workflows/manual-compose-recreate.yml
@@ -3,6 +3,8 @@ name: Manual Compose Recreate
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   compose-recreate:
     name: Compose Recreate On Server

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - ci/auto-test # For testing the workflow itself
 
+permissions:
+  contents: read
+
 jobs:
   frontend-test:
     name: Frontend SvelteKit Tests


### PR DESCRIPTION
## Summary

- add explicit `permissions` blocks to workflows flagged by CodeQL
- keep checkout-based test jobs at `contents: read`
- set token permissions to `{}` for SSH/manual jobs that do not need `GITHUB_TOKEN`

## Why

Fixes #186.

CodeQL reports `actions/missing-workflow-permissions` for several workflows. Without explicit permissions, the workflow token can receive broader default permissions than the job needs.

## Validation

- Parsed updated workflow YAML files with Ruby's YAML parser
- `git diff --check`
