### PR TITLE
fix: QRコードの重複検証を防止

### DIFF
--- a/backapp/internal/handler/qrcode_handler.go
+++ b/backapp/internal/handler/qrcode_handler.go
@@ -251,6 +251,16 @@ func (h *QRCodeHandler) VerifyQRCodeHandler(c *gin.Context) {
 		return
 	}
 
+	consumed, err := h.tokenStore.ConsumeActiveToken(qrData.UserID, qrData.EventID, qrData.SportID, token)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to consume QR code token"})
+		return
+	}
+	if !consumed {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "QRコードは無効または期限切れです"})
+		return
+	}
+
 	// Confirm team member (参加本登録)
 	err = h.teamRepo.ConfirmTeamMember(team.ID, qrData.UserID)
 	if err != nil {

--- a/backapp/internal/handler/qrcode_token_store.go
+++ b/backapp/internal/handler/qrcode_token_store.go
@@ -11,6 +11,7 @@ import (
 type QRCodeTokenStore interface {
 	SaveActiveToken(userID string, eventID, sportID int, token string, ttl time.Duration) error
 	GetActiveToken(userID string, eventID, sportID int) (string, error)
+	ConsumeActiveToken(userID string, eventID, sportID int, token string) (bool, error)
 }
 
 type redisQRCodeTokenStore struct{}
@@ -29,6 +30,10 @@ func (s *redisQRCodeTokenStore) GetActiveToken(userID string, eventID, sportID i
 		return "", nil
 	}
 	return token, err
+}
+
+func (s *redisQRCodeTokenStore) ConsumeActiveToken(userID string, eventID, sportID int, token string) (bool, error) {
+	return middleware.CompareAndDeleteRedisValue(qrCodeTokenKey(userID, eventID, sportID), token)
 }
 
 func qrCodeTokenKey(userID string, eventID, sportID int) string {

--- a/backapp/internal/middleware/auth.go
+++ b/backapp/internal/middleware/auth.go
@@ -63,6 +63,24 @@ func GetRedisValue(key string) (string, error) {
 	return redisClient.Get(context.Background(), key).Result()
 }
 
+func CompareAndDeleteRedisValue(key, expectedValue string) (bool, error) {
+	if redisClient == nil {
+		return false, fmt.Errorf("redis client is not initialized")
+	}
+
+	const script = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
+end
+return 0
+`
+	result, err := redisClient.Eval(context.Background(), script, []string{key}, expectedValue).Int()
+	if err != nil {
+		return false, err
+	}
+	return result == 1, nil
+}
+
 func IsRequestSecure(r *http.Request) bool {
 	if r.TLS != nil {
 		return true

--- a/backapp/tests/handler/main_test.go
+++ b/backapp/tests/handler/main_test.go
@@ -315,6 +315,11 @@ func (m *MockQRCodeTokenStore) GetActiveToken(userID string, eventID, sportID in
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockQRCodeTokenStore) ConsumeActiveToken(userID string, eventID, sportID int, token string) (bool, error) {
+	args := m.Called(userID, eventID, sportID, token)
+	return args.Bool(0), args.Error(1)
+}
+
 var _ handler.QRCodeTokenStore = (*MockQRCodeTokenStore)(nil)
 
 func (m *MockTournamentRepository) SaveTournament(eventID int, sportID int, sportName string, tournamentData *models.TournamentData, teams []*models.Team) error {

--- a/backapp/tests/handler/qrcode_handler_test.go
+++ b/backapp/tests/handler/qrcode_handler_test.go
@@ -571,6 +571,7 @@ func TestQRCodeHandler_VerifyQRCodeHandler(t *testing.T) {
 		mockTeamRepo.On("GetTeamByClassAndSport", classID, 1, 1).Return(team, nil).Once()
 		mockTeamRepo.On("ConfirmTeamMember", teamID, userID).Return(nil).Once()
 		mockTokenStore.On("GetActiveToken", userID, 1, 1).Return("test-token", nil).Once()
+		mockTokenStore.On("ConsumeActiveToken", userID, 1, 1, "test-token").Return(true, nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -673,6 +674,7 @@ func TestQRCodeHandler_VerifyQRCodeHandler(t *testing.T) {
 		mockTeamRepo.On("GetConfirmedTeamMembersCount", teamID).Return(confirmedCount, nil).Once()
 		mockClassRepo.On("GetClassByID", classID).Return(class, nil).Once()
 		mockTokenStore.On("GetActiveToken", userID, 1, 1).Return("test-token", nil).Once()
+		mockTokenStore.On("ConsumeActiveToken", userID, 1, 1, "test-token").Return(true, nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -963,6 +965,82 @@ func TestQRCodeHandler_VerifyQRCodeHandler(t *testing.T) {
 
 		mockTokenStore.AssertExpectations(t)
 		mockTeamRepo.AssertNotCalled(t, "GetTeamsByUserID")
+	})
+
+	t.Run("Failure - QR code token already consumed", func(t *testing.T) {
+		mockTeamRepo := new(MockTeamRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockUserRepo := new(MockUserRepository)
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockTokenStore := new(MockQRCodeTokenStore)
+
+		h := handler.NewQRCodeHandler(mockTeamRepo, mockSportRepo, mockUserRepo, mockEventRepo, mockClassRepo).WithTokenStore(mockTokenStore)
+
+		userID := "test-user-id"
+		displayName := "Test User"
+		classID := 1
+		teamID := 1
+		qrData := models.QRCodeData{
+			EventID:     1,
+			SportID:     1,
+			SportName:   "Basketball",
+			UserID:      userID,
+			DisplayName: displayName,
+			Timestamp:   time.Now().Unix(),
+			ExpiresAt:   time.Now().Unix() + 10,
+		}
+
+		combinedJSON, _ := json.Marshal(map[string]interface{}{
+			"token": "test-token",
+			"data":  qrData,
+		})
+		reqBody := models.QRCodeVerifyRequest{
+			QRCodeData: base64.URLEncoding.EncodeToString(combinedJSON),
+		}
+
+		teams := []*models.TeamWithSport{
+			{
+				ID:        teamID,
+				Name:      "Team A",
+				ClassID:   classID,
+				SportID:   1,
+				EventID:   1,
+				SportName: "Basketball",
+			},
+		}
+		team := &models.Team{
+			ID:      teamID,
+			Name:    "Team A",
+			ClassID: classID,
+			SportID: 1,
+			EventID: 1,
+		}
+
+		mockTokenStore.On("GetActiveToken", userID, 1, 1).Return("test-token", nil).Once()
+		mockTeamRepo.On("GetTeamsByUserID", userID).Return(teams, nil).Once()
+		mockTeamRepo.On("GetTeamByClassAndSport", classID, 1, 1).Return(team, nil).Once()
+		mockTokenStore.On("ConsumeActiveToken", userID, 1, 1, "test-token").Return(false, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		jsonBody, _ := json.Marshal(reqBody)
+		c.Request, _ = http.NewRequest(http.MethodPost, "/api/qrcode/verify", bytes.NewBuffer(jsonBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		h.VerifyQRCodeHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "QRコードは無効または期限切れです", response["error"])
+
+		mockTeamRepo.AssertNotCalled(t, "ConfirmTeamMember")
+		mockTeamRepo.AssertExpectations(t)
+		mockTokenStore.AssertExpectations(t)
 	})
 
 	t.Run("Failure - User not assigned to sport", func(t *testing.T) {


### PR DESCRIPTION
## 概要
- チームメンバーを本登録する前に、有効なQRコードトークンを消費するようにしました
- Redis上でトークンの一致確認と削除を原子的に行うヘルパーを追加しました
- 消費済みQRコードを再利用した場合の回帰テストを追加しました

## 原因
QRコード検証では `GetActiveToken` でRedis上の有効トークンを確認していましたが、確認後もトークンがTTL切れまで残っていました。そのため、TTL内に同じQRコードを複数回スキャンすると、すべて成功扱いになり `ConfirmTeamMember` が複数回呼ばれる可能性がありました。

## 影響
QRコードは正常に検証された時点で一度だけ使用可能になります。同じQRコードを再スキャンした場合は、既存の無効または期限切れQRコードのレスポンスを返し、`ConfirmTeamMember` は呼ばれません。

Closes #189

## 確認内容
- `go test ./tests/handler -run TestQRCodeHandler_VerifyQRCodeHandler`
- `go test ./...`