### PR TITLE
通知有効化の導線改善と購読状況の可視化

### DIFF
--- a/backapp/internal/handler/notification_handler.go
+++ b/backapp/internal/handler/notification_handler.go
@@ -127,7 +127,7 @@ func (h *NotificationHandler) CreateNotification(c *gin.Context) {
 	go h.dispatchPushNotifications(int(notificationID), req.Title, req.Body, req.Type, targetRoles)
 
 	c.JSON(http.StatusCreated, gin.H{
-		"message":        "通知を送信しました",
+		"message":        "通知を作成しました。Push通知は通知を有効化済みのユーザーに送信されます",
 		"notificationId": notificationID,
 	})
 }
@@ -180,6 +180,31 @@ func (h *NotificationHandler) ListAvailableRoles(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"roles": roles})
+}
+
+func (h *NotificationHandler) GetPushSubscriptionStats(c *gin.Context) {
+	availableRoles, err := h.RoleRepo.GetAllRoles()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "ロール情報の取得に失敗しました"})
+		return
+	}
+
+	targetRoles, err := normalizeTargetRoles(c.QueryArray("roles"), availableRoles)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	stats, err := h.NotificationRepo.GetPushSubscriptionStatsByRoles(targetRoles)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "購読状況の取得に失敗しました"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"target_roles": targetRoles,
+		"stats":        stats,
+	})
 }
 
 type updateNotificationFiltersRequest struct {

--- a/backapp/internal/models/notification.go
+++ b/backapp/internal/models/notification.go
@@ -21,3 +21,9 @@ type PushSubscription struct {
 	P256dhKey string    `json:"p256dh_key"`
 	CreatedAt time.Time `json:"created_at"`
 }
+
+type PushSubscriptionStats struct {
+	TargetUserCount           int `json:"target_user_count"`
+	SubscribedUserCount       int `json:"subscribed_user_count"`
+	SubscriptionEndpointCount int `json:"subscription_endpoint_count"`
+}

--- a/backapp/internal/repository/notification_repository.go
+++ b/backapp/internal/repository/notification_repository.go
@@ -14,6 +14,7 @@ type NotificationRepository interface {
 	GetUserIDsByRoles(roleNames []string) ([]string, error)
 	GetPushSubscriptionsByUserIDs(userIDs []string) ([]models.PushSubscription, error)
 	GetPushSubscriptionsByUserID(userID string) ([]models.PushSubscription, error)
+	GetPushSubscriptionStatsByRoles(roleNames []string) (models.PushSubscriptionStats, error)
 	UpsertPushSubscription(userID, endpoint, authKey, p256dhKey string) error
 	DeletePushSubscription(userID, endpoint string) error
 }
@@ -262,6 +263,38 @@ func (r *notificationRepository) GetPushSubscriptionsByUserID(userID string) ([]
 	}
 
 	return subs, nil
+}
+
+func (r *notificationRepository) GetPushSubscriptionStatsByRoles(roleNames []string) (models.PushSubscriptionStats, error) {
+	if len(roleNames) == 0 {
+		return models.PushSubscriptionStats{}, nil
+	}
+
+	placeholders := strings.Repeat(",?", len(roleNames)-1)
+	query := `
+		SELECT
+			COUNT(DISTINCT u.id) AS target_user_count,
+			COUNT(DISTINCT ps.user_id) AS subscribed_user_count,
+			COUNT(DISTINCT ps.endpoint) AS subscription_endpoint_count
+		FROM users u
+		INNER JOIN user_roles ur ON u.id = ur.user_id
+		INNER JOIN roles r ON ur.role_id = r.id
+		LEFT JOIN push_subscriptions ps ON u.id = ps.user_id
+		WHERE r.name IN (?` + placeholders + `)
+	`
+
+	args := make([]interface{}, len(roleNames))
+	for i, role := range roleNames {
+		args[i] = role
+	}
+
+	var stats models.PushSubscriptionStats
+	err := r.db.QueryRow(query, args...).Scan(
+		&stats.TargetUserCount,
+		&stats.SubscribedUserCount,
+		&stats.SubscriptionEndpointCount,
+	)
+	return stats, err
 }
 
 func (r *notificationRepository) UpsertPushSubscription(userID, endpoint, authKey, p256dhKey string) error {

--- a/backapp/internal/router/router.go
+++ b/backapp/internal/router/router.go
@@ -313,6 +313,7 @@ func SetupRouter(db *sql.DB, cfg *config.Config, hubManager *websocket.HubManage
 			{
 				rootNotifications.POST("", notificationHandler.CreateNotification)
 				rootNotifications.GET("/roles", notificationHandler.ListAvailableRoles)
+				rootNotifications.GET("/subscription-stats", notificationHandler.GetPushSubscriptionStats)
 			}
 
 			rootUsers := root.Group("/users")

--- a/backapp/tests/handler/main_test.go
+++ b/backapp/tests/handler/main_test.go
@@ -611,6 +611,11 @@ func (m *MockNotificationRepository) GetPushSubscriptionsByUserID(userID string)
 	return args.Get(0).([]models.PushSubscription), args.Error(1)
 }
 
+func (m *MockNotificationRepository) GetPushSubscriptionStatsByRoles(roleNames []string) (models.PushSubscriptionStats, error) {
+	args := m.Called(roleNames)
+	return args.Get(0).(models.PushSubscriptionStats), args.Error(1)
+}
+
 func (m *MockNotificationRepository) UpsertPushSubscription(userID, endpoint, authKey, p256dhKey string) error {
 	args := m.Called(userID, endpoint, authKey, p256dhKey)
 	return args.Error(0)

--- a/backapp/tests/handler/notification_handler_test.go
+++ b/backapp/tests/handler/notification_handler_test.go
@@ -329,6 +329,50 @@ func TestNotificationHandler_GetSubscription_RepositoryError(t *testing.T) {
 	mockNotifRepo.AssertExpectations(t)
 }
 
+func TestNotificationHandler_GetPushSubscriptionStats_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockNotifRepo := new(MockNotificationRepository)
+	mockEventRepo := new(MockEventRepository)
+	mockRoleRepo := new(MockRoleRepository)
+	mockUserRepo := new(MockUserRepository)
+
+	h := handler.NewNotificationHandler(mockNotifRepo, mockEventRepo, mockRoleRepo, mockUserRepo, "", "")
+
+	mockRoleRepo.On("GetAllRoles").Return([]models.Role{
+		{ID: 1, Name: "student"},
+		{ID: 2, Name: "admin"},
+	}, nil).Once()
+	mockNotifRepo.On("GetPushSubscriptionStatsByRoles", []string{"admin", "student"}).
+		Return(models.PushSubscriptionStats{
+			TargetUserCount:           10,
+			SubscribedUserCount:       6,
+			SubscriptionEndpointCount: 8,
+		}, nil).Once()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/root/notifications/subscription-stats?roles=Student&roles=admin", nil)
+
+	h.GetPushSubscriptionStats(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, []interface{}{"admin", "student"}, response["target_roles"])
+
+	stats := response["stats"].(map[string]interface{})
+	assert.Equal(t, float64(10), stats["target_user_count"])
+	assert.Equal(t, float64(6), stats["subscribed_user_count"])
+	assert.Equal(t, float64(8), stats["subscription_endpoint_count"])
+
+	mockRoleRepo.AssertExpectations(t)
+	mockNotifRepo.AssertExpectations(t)
+}
+
 func TestNotificationHandler_UpdateNotificationFilters_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/frontapp/e2e/root-notification.spec.js
+++ b/frontapp/e2e/root-notification.spec.js
@@ -70,7 +70,7 @@ test.describe('通知管理 (root)', () => {
     expect(body.target_roles).toContain('admin');
     expect(body.type).toBe('general');
 
-    await expect(page.getByText('通知を送信しました。')).toBeVisible();
+    await expect(page.getByText('通知を作成しました。Push通知は通知を有効化済みのユーザーに送信されます。')).toBeVisible();
     await expect(page.getByLabel('タイトル')).toHaveValue('');
     await expect(page.getByLabel('本文')).toHaveValue('');
   });

--- a/frontapp/scripts/mock-backend.js
+++ b/frontapp/scripts/mock-backend.js
@@ -687,6 +687,20 @@ createServer(async (req, res) => {
     return;
   }
 
+  if (url.pathname === '/api/root/notifications/subscription-stats' && req.method === 'GET') {
+    const roles = url.searchParams.getAll('roles');
+    const roleCount = roles.length || 1;
+    sendJson(res, 200, {
+      target_roles: roles,
+      stats: {
+        target_user_count: roleCount * 10,
+        subscribed_user_count: roleCount * 6,
+        subscription_endpoint_count: roleCount * 8
+      }
+    });
+    return;
+  }
+
   if (url.pathname === '/api/notifications' && req.method === 'GET') {
     sendJson(res, 200, { notifications });
     return;

--- a/frontapp/src/lib/components/NotificationSettings.svelte
+++ b/frontapp/src/lib/components/NotificationSettings.svelte
@@ -2,10 +2,11 @@
   import { browser } from '$app/environment';
   import { ensurePushSubscription, userHasPushEligibleRole } from '$lib/utils/push.js';
   import { isPWAInstalled, getDeviceType } from '$lib/utils/pwa.js';
+  import { updatePushSubscriptionStatus } from '$lib/stores/pushSubscriptionStore.js';
   import { env as publicEnv } from '$env/dynamic/public';
   import { onMount } from 'svelte';
 
-  let { user } = $props();
+  let { user, prominent = false } = $props();
 
   let isSubscribed = $state(false);
   let isLoading = $state(false);
@@ -26,9 +27,20 @@
       isPWA = isPWAInstalled();
       checkNotificationSupport();
       checkPermissionStatus();
+      publishStatus();
       loadSubscriptionStatus();
     }
   });
+
+  function publishStatus() {
+    updatePushSubscriptionStatus({
+      isSubscribed,
+      isSupported,
+      canEnable: canEnableNotifications,
+      permission: permissionStatus,
+      vapidKeySet
+    });
+  }
 
   function checkNotificationSupport() {
     isSupported = 'Notification' in window && 
@@ -63,6 +75,8 @@
       }
     } catch (error) {
       console.error('[notification] Failed to load subscription status:', error);
+    } finally {
+      publishStatus();
     }
   }
 
@@ -124,6 +138,7 @@
     } finally {
       isLoading = false;
       checkPermissionStatus();
+      publishStatus();
     }
   }
 
@@ -167,6 +182,7 @@
       errorMessage = '通知の無効化中にエラーが発生しました。';
     } finally {
       isLoading = false;
+      publishStatus();
     }
   }
 
@@ -198,12 +214,16 @@
 
 </script>
 
-<div class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+<div class="{prominent && canEnableNotifications && isSupported && !isSubscribed ? 'rounded-lg border border-amber-200 bg-amber-50 p-5 shadow-sm' : 'rounded-lg border border-gray-200 bg-white p-5 shadow-sm'}">
   <div class="flex items-center justify-between mb-4">
     <div>
-      <h3 class="text-lg font-semibold text-gray-800">プッシュ通知設定</h3>
-      <p class="mt-1 text-sm text-gray-600">
-        モバイルデバイスで通知を受け取ることができます
+      <h3 class="text-lg font-semibold {prominent && !isSubscribed ? 'text-amber-900' : 'text-gray-800'}">プッシュ通知設定</h3>
+      <p class="mt-1 text-sm {prominent && !isSubscribed ? 'text-amber-800' : 'text-gray-600'}">
+        {#if prominent && canEnableNotifications && isSupported && !isSubscribed}
+          重要なお知らせを見逃さないよう、この端末で通知を有効にしてください。
+        {:else}
+          モバイルデバイスで通知を受け取ることができます
+        {/if}
       </p>
     </div>
     {#if isSupported}

--- a/frontapp/src/lib/components/Sidebar.svelte
+++ b/frontapp/src/lib/components/Sidebar.svelte
@@ -1,7 +1,10 @@
 <script>
   import { isSidebarOpen } from '$lib/stores/sidebarStore.js';
   import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { env as publicEnv } from '$env/dynamic/public';
   import { notificationBadgeCount, refreshNotificationBadge } from '$lib/stores/notificationBadgeStore.js';
+  import { pushSubscriptionStatus, updatePushSubscriptionStatus } from '$lib/stores/pushSubscriptionStore.js';
 
   /** @type {import('@sveltejs/kit').MaybePromise<import('../../routes/$types').LayoutData>} */
   let { user } = $props();
@@ -14,6 +17,14 @@
   const isAdmin = hasRole('admin');
   const isRoot = hasRole('root');
   const canSeeNotifications = isStudent || isAdmin || isRoot;
+  const vapidKeySet = browser ? (publicEnv.PUBLIC_WEBPUSH_PUBLIC_KEY ?? publicEnv.PUBLIC_WEBPUSH_KEY ?? '') !== '' : false;
+  let shouldShowPushSetupBadge = $derived(
+    canSeeNotifications &&
+    $pushSubscriptionStatus.loaded &&
+    $pushSubscriptionStatus.isSupported &&
+    $pushSubscriptionStatus.vapidKeySet &&
+    !$pushSubscriptionStatus.isSubscribed
+  );
 
   onMount(() => {
     if (!canSeeNotifications) return;
@@ -25,6 +36,7 @@
     };
 
     refreshBadge();
+    refreshPushSubscriptionStatus();
 
     const interval = setInterval(refreshBadge, 60 * 1000);
     const handleVisibilityChange = () => {
@@ -47,6 +59,52 @@
       navigator.serviceWorker?.removeEventListener('message', handleServiceWorkerMessage);
     };
   });
+
+  async function refreshPushSubscriptionStatus() {
+    if (!browser) return;
+
+    const isSupported = 'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window;
+    const permission = 'Notification' in window ? Notification.permission : 'default';
+
+    if (!isSupported || !vapidKeySet) {
+      updatePushSubscriptionStatus({
+        isSubscribed: false,
+        isSupported,
+        canEnable: canSeeNotifications,
+        permission,
+        vapidKeySet
+      });
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/notifications/subscription', {
+        credentials: 'include'
+      });
+      const data = response.ok ? await response.json() : {};
+      const endpoints = Array.isArray(data.endpoints) ? data.endpoints : [];
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+      const endpoint = subscription?.endpoint ?? '';
+
+      updatePushSubscriptionStatus({
+        isSubscribed: endpoint !== '' && endpoints.includes(endpoint),
+        isSupported,
+        canEnable: canSeeNotifications,
+        permission,
+        vapidKeySet
+      });
+    } catch (error) {
+      console.error('[notification] Failed to refresh push subscription status:', error);
+      updatePushSubscriptionStatus({
+        isSubscribed: false,
+        isSupported,
+        canEnable: canSeeNotifications,
+        permission,
+        vapidKeySet
+      });
+    }
+  }
 
   function closeSidebar(event) {
     if (event) {
@@ -91,6 +149,15 @@
       <svg class="w-6 h-6 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
     </button>
   </div>
+  {#if shouldShowPushSetupBadge}
+    <a
+      href="/dashboard"
+      class="mx-3 mb-2 rounded-md border border-amber-300 bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-900 hover:bg-amber-200"
+      onclick={handleLinkClick}
+    >
+      {$pushSubscriptionStatus.permission === 'denied' ? '通知拒否中' : '通知未設定'}
+    </a>
+  {/if}
   <nav class="flex-1 px-2 py-4 space-y-1 overflow-y-auto">
     <!-- Root Menu -->
     {#if isRoot}
@@ -203,14 +270,21 @@
         </a>
         <a href="/dashboard/student/notification" class="flex items-center justify-between px-4 py-2 text-sm font-medium rounded-md hover:bg-gray-700" onclick={handleLinkClick}>
           <span>通知</span>
-          {#if $notificationBadgeCount > 0}
-            <span
-              class="ml-3 inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-xs font-bold leading-none text-white shadow"
-              aria-label={`未読通知 ${$notificationBadgeCount} 件`}
-            >
-              {$notificationBadgeCount > 99 ? '99+' : $notificationBadgeCount}
-            </span>
-          {/if}
+          <span class="ml-3 flex items-center gap-2">
+            {#if shouldShowPushSetupBadge}
+              <span class="rounded-full bg-amber-400 px-2 py-0.5 text-xs font-bold text-amber-950">
+                {$pushSubscriptionStatus.permission === 'denied' ? '拒否中' : '未設定'}
+              </span>
+            {/if}
+            {#if $notificationBadgeCount > 0}
+              <span
+                class="inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-xs font-bold leading-none text-white shadow"
+                aria-label={`未読通知 ${$notificationBadgeCount} 件`}
+              >
+                {$notificationBadgeCount > 99 ? '99+' : $notificationBadgeCount}
+              </span>
+            {/if}
+          </span>
         </a>
         <a href="/dashboard/student/notification-request" class="flex items-center px-4 py-2 text-sm font-medium rounded-md hover:bg-gray-700" onclick={handleLinkClick}>
           通知申請

--- a/frontapp/src/lib/stores/pushSubscriptionStore.js
+++ b/frontapp/src/lib/stores/pushSubscriptionStore.js
@@ -1,0 +1,18 @@
+import { writable } from 'svelte/store';
+
+export const pushSubscriptionStatus = writable({
+	loaded: false,
+	isSubscribed: false,
+	isSupported: false,
+	canEnable: false,
+	permission: 'default',
+	vapidKeySet: false
+});
+
+export function updatePushSubscriptionStatus(nextStatus) {
+	pushSubscriptionStatus.update((current) => ({
+		...current,
+		...nextStatus,
+		loaded: true
+	}));
+}

--- a/frontapp/src/routes/dashboard/+layout.svelte
+++ b/frontapp/src/routes/dashboard/+layout.svelte
@@ -6,6 +6,7 @@
   import PWANotificationBanner from '$lib/components/PWANotificationBanner.svelte';
   import { isPWAInstalled, isPWAInstallable } from '$lib/utils/pwa.js';
   import { isSidebarOpen } from '$lib/stores/sidebarStore.js';
+  import { pushSubscriptionStatus } from '$lib/stores/pushSubscriptionStore.js';
 
   let { children } = $props();
   let { data } = $page;
@@ -14,6 +15,14 @@
   let showEditDisplayNameModal = $state(false);
   let showPWANotification = $state(false);
   let isMobile = $state(false);
+  let canSeeNotifications = $derived(user?.roles?.some(role => ['student', 'admin', 'root'].includes(role.name)));
+  let shouldShowPushSetupBadge = $derived(
+    canSeeNotifications &&
+    $pushSubscriptionStatus.loaded &&
+    $pushSubscriptionStatus.isSupported &&
+    $pushSubscriptionStatus.vapidKeySet &&
+    !$pushSubscriptionStatus.isSubscribed
+  );
   
   onMount(() => {
     if (browser) {
@@ -112,6 +121,14 @@
           <a href="/dashboard" data-sveltekit-preload-data="hover" class="flex items-center"><h1 class="text-2xl font-bold text-gray-800">Dashboard</h1></a>
         </div>
         <div class="flex items-center pointer-events-auto">
+          {#if shouldShowPushSetupBadge}
+            <a
+              href="/dashboard"
+              class="mr-3 rounded-md border border-amber-300 bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-900 hover:bg-amber-200"
+            >
+              {$pushSubscriptionStatus.permission === 'denied' ? '通知拒否中' : '通知未設定'}
+            </a>
+          {/if}
           <button 
             type="button"
             onclick={handleDisplayNameClick}

--- a/frontapp/src/routes/dashboard/+page.svelte
+++ b/frontapp/src/routes/dashboard/+page.svelte
@@ -221,6 +221,10 @@
   {/if}
 
   <section class="space-y-6">
+    <NotificationSettings user={user} prominent={true} />
+  </section>
+
+  <section class="space-y-6">
     <div class="flex items-center justify-between">
       <h2 class="text-2xl font-semibold text-gray-900">資料</h2>
     </div>
@@ -405,13 +409,6 @@
       {/if}
     </section>
   {/if}
-
-  <section class="space-y-6">
-    <div class="flex items-center justify-between">
-      <h2 class="text-2xl font-semibold text-gray-900">通知</h2>
-    </div>
-    <NotificationSettings user={user} />
-  </section>
 
   {#if data.isClassRep}
     <section class="space-y-6">

--- a/frontapp/src/routes/dashboard/root/event-management/+page.svelte
+++ b/frontapp/src/routes/dashboard/root/event-management/+page.svelte
@@ -130,7 +130,7 @@
         const d = await resp.json();
         throw new Error(d.error || 'Failed to send notification');
       }
-      alert('アンケート通知を送信しました。');
+      alert('アンケート通知を作成しました。Push通知は通知を有効化済みのユーザーに送信されます。');
     } catch (err) {
       alert(err.message);
     }

--- a/frontapp/src/routes/dashboard/root/event-management/event-management.svelte.spec.js
+++ b/frontapp/src/routes/dashboard/root/event-management/event-management.svelte.spec.js
@@ -323,7 +323,7 @@ describe('Event Management Page', () => {
 
     expect(notifyCall).toBeTruthy();
     expect(confirm).toHaveBeenCalledWith('アンケート通知を全ユーザーに送信します。よろしいですか？');
-    expect(alert).toHaveBeenCalledWith('アンケート通知を送信しました。');
+    expect(alert).toHaveBeenCalledWith('アンケート通知を作成しました。Push通知は通知を有効化済みのユーザーに送信されます。');
   });
 
   it('秋季大会の得点CSVをインポートできること', async () => {

--- a/frontapp/src/routes/dashboard/root/notification/+page.server.js
+++ b/frontapp/src/routes/dashboard/root/notification/+page.server.js
@@ -41,18 +41,41 @@ export async function load({ fetch, request }) {
 			console.error('Failed to fetch roles:', rolesResponse.status, errorText);
 		}
 
+		let subscriptionStats = null;
+		const defaultTargetRoles = roles.some((role) => (role.name ?? role.Name) === 'student')
+			? ['student']
+			: roles.slice(0, 1).map((role) => role.name ?? role.Name).filter(Boolean);
+		if (defaultTargetRoles.length > 0) {
+			const statsParams = new URLSearchParams();
+			for (const role of defaultTargetRoles) {
+				statsParams.append('roles', role);
+			}
+
+			const statsResponse = await fetch(`${BACKEND_URL}/api/root/notifications/subscription-stats?${statsParams.toString()}`, {
+				headers
+			});
+			if (statsResponse.ok) {
+				const statsPayload = await statsResponse.json();
+				subscriptionStats = statsPayload.stats ?? null;
+			} else {
+				const errorText = await statsResponse.text();
+				console.error('Failed to fetch subscription stats:', statsResponse.status, errorText);
+			}
+		}
+
 		return {
 			notifications: notificationsPayload.notifications ?? [],
-			roles
+			roles,
+			subscriptionStats
 		};
 	} catch (error) {
 		console.error('Error loading notifications:', error);
 		return {
 			notifications: [],
 			roles: [],
+			subscriptionStats: null,
 			error: error.message
 		};
 	}
 }
-
 

--- a/frontapp/src/routes/dashboard/root/notification/+page.svelte
+++ b/frontapp/src/routes/dashboard/root/notification/+page.svelte
@@ -4,6 +4,7 @@
 
   let { data } = $page;
   let notifications = $state(data.notifications ? [...data.notifications] : []);
+  let subscriptionStats = $state(data.subscriptionStats ?? null);
 
   const roleLabelMap = {
     student: '学生',
@@ -53,6 +54,7 @@
   let errorMessage = $state('');
   let isSubmitting = $state(false);
   let isReloading = $state(false);
+  let isStatsLoading = $state(false);
   let isInteractive = $state(false);
 
   onMount(() => {
@@ -60,6 +62,7 @@
   });
   function toggleRole(roleName) {
     selectedRoles = { ...selectedRoles, [roleName]: !selectedRoles[roleName] };
+    refreshSubscriptionStats();
   }
 
   function resetSelectedRoles() {
@@ -70,6 +73,39 @@
     return availableRoles
       .map((role) => role.name)
       .filter((roleName) => selectedRoles[roleName]);
+  }
+
+  function getSelectedRoleLabels() {
+    return getSelectedRoles().map((role) => roleLabelMap[role] ?? role).join('、');
+  }
+
+  async function refreshSubscriptionStats() {
+    const targetRoles = getSelectedRoles();
+    if (targetRoles.length === 0) {
+      subscriptionStats = null;
+      return;
+    }
+
+    isStatsLoading = true;
+    try {
+      const query = targetRoles
+        .map((role) => `roles=${encodeURIComponent(role)}`)
+        .join('&');
+
+      const response = await fetch(`/api/root/notifications/subscription-stats?${query}`);
+      if (!response.ok) {
+        const errText = await response.text();
+        throw new Error(errText || '購読状況の取得に失敗しました。');
+      }
+
+      const result = await response.json();
+      subscriptionStats = result.stats ?? null;
+    } catch (error) {
+      console.error('購読状況の取得に失敗しました:', error);
+      subscriptionStats = null;
+    } finally {
+      isStatsLoading = false;
+    }
   }
 
   async function handleSubmit() {
@@ -107,12 +143,13 @@
         throw new Error(err.error || '通知の作成に失敗しました。');
       }
 
-      message = '通知を送信しました。';
+      message = '通知を作成しました。Push通知は通知を有効化済みのユーザーに送信されます。';
       title = '';
       body = '';
       resetSelectedRoles();
 
       await refreshNotifications();
+      await refreshSubscriptionStats();
     } catch (error) {
       errorMessage = error.message;
     } finally {
@@ -188,6 +225,45 @@
 
   <section class="bg-white shadow rounded-lg p-6 space-y-6">
     <h2 class="text-xl font-semibold text-gray-800">新しい通知を作成</h2>
+
+    <div class="rounded-lg border border-indigo-100 bg-indigo-50 p-4">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-indigo-900">Push通知の受信可能状況</h3>
+          <p class="mt-1 text-sm text-indigo-800">
+            宛先: {getSelectedRoleLabels() || '未選択'}
+          </p>
+        </div>
+        <button
+          type="button"
+          class="rounded-md border border-indigo-300 bg-white px-3 py-1.5 text-sm font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-50"
+          onclick={refreshSubscriptionStats}
+          disabled={!isInteractive || isStatsLoading || getSelectedRoles().length === 0}
+        >
+          {isStatsLoading ? '確認中...' : '再確認'}
+        </button>
+      </div>
+      {#if subscriptionStats}
+        <div class="mt-4 grid gap-3 sm:grid-cols-3">
+          <div class="rounded-md bg-white p-3">
+            <p class="text-xs font-medium text-gray-500">対象ユーザー</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{subscriptionStats.target_user_count ?? 0}</p>
+          </div>
+          <div class="rounded-md bg-white p-3">
+            <p class="text-xs font-medium text-gray-500">通知有効ユーザー</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{subscriptionStats.subscribed_user_count ?? 0}</p>
+          </div>
+          <div class="rounded-md bg-white p-3">
+            <p class="text-xs font-medium text-gray-500">登録デバイス</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{subscriptionStats.subscription_endpoint_count ?? 0}</p>
+          </div>
+        </div>
+      {:else}
+        <p class="mt-4 text-sm text-indigo-800">
+          宛先ロールを選択すると、Push通知を受け取れる人数を確認できます。
+        </p>
+      {/if}
+    </div>
 
     <div class="space-y-4">
       <div>

--- a/frontapp/src/routes/dashboard/root/notification/notification.svelte.spec.js
+++ b/frontapp/src/routes/dashboard/root/notification/notification.svelte.spec.js
@@ -21,7 +21,12 @@ vi.mock('$app/stores', () => ({
             { id: 1, name: 'student' },
             { id: 2, name: 'admin' },
             { id: 3, name: 'root' }
-          ]
+          ],
+          subscriptionStats: {
+            target_user_count: 12,
+            subscribed_user_count: 8,
+            subscription_endpoint_count: 10
+          }
         }
       });
 
@@ -63,6 +68,19 @@ describe('Notification Management Page', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({ notifications })
+        });
+      }
+
+      if (typeof url === 'string' && url.startsWith('/api/root/notifications/subscription-stats?')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            stats: {
+              target_user_count: 12,
+              subscribed_user_count: 8,
+              subscription_endpoint_count: 10
+            }
+          })
         });
       }
 
@@ -116,7 +134,7 @@ describe('Notification Management Page', () => {
       target_roles: ['student', 'admin']
     });
 
-    await expect.element(page.getByText('通知を送信しました。')).toBeInTheDocument();
+    await expect.element(page.getByText('通知を作成しました。Push通知は通知を有効化済みのユーザーに送信されます。')).toBeInTheDocument();
     await expect.element(page.getByText('競技開始時間変更')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
- ダッシュボード上部にプッシュ通知設定を移動し、未設定時は目立つ案内を表示します
- サイドバーとヘッダーに「通知未設定」または「通知拒否中」の状態表示を追加します
- rootの通知管理画面で、宛先ロールごとの対象ユーザー数・通知有効ユーザー数・登録デバイス数を確認できるようにします
- 通知作成後の成功メッセージを、Push通知が有効化済みユーザーに送信されることが分かる文言に変更します

## 背景
通知送信のコードは存在し、通知が届くユーザーも確認できていました。一方で、通知有効化ボタンが見つけにくく、未購読ユーザーにはPush通知が届かないことが分かりづらい状態でした。

## 変更内容
- `pushSubscriptionStore` を追加し、現在端末のPush購読状態を共有
- `NotificationSettings` をダッシュボード上部向けに強調表示できるよう調整
- サイドバーとヘッダーに通知設定状態のバッジを追加
- backendに `/api/root/notifications/subscription-stats` を追加
- root通知管理画面にPush通知の受信可能状況カードを追加
- mock backendと関連テストの文言・レスポンスを更新

## 確認内容
- `go test ./...`
- `npm run lint`
- `npm run build`

## 補足
`npm run lint` は既存の未使用変数warningが2件ありますが、errorはありません。