### PR TITLE
#159 得点非表示中のマイページで順位・得点を隠す

### DIFF
--- a/backapp/internal/handler/class_handler.go
+++ b/backapp/internal/handler/class_handler.go
@@ -197,6 +197,21 @@ func (h *ClassHandler) GetClassScores(c *gin.Context) {
 		eventID = activeEventID
 	}
 
+	event, err := h.eventRepo.GetEventByID(eventID)
+	if err != nil {
+		log.Printf("GetEventByID error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get event"})
+		return
+	}
+	if event == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Event not found"})
+		return
+	}
+	if event.HideScores && !canViewHiddenClassScores(c) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "得点一覧は現在非表示です。"})
+		return
+	}
+
 	scores, err := h.classRepo.GetClassScoresByEvent(eventID)
 	if err != nil {
 		log.Printf("GetClassScoresByEvent error: %v", err)
@@ -205,6 +220,25 @@ func (h *ClassHandler) GetClassScores(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, scores)
+}
+
+func canViewHiddenClassScores(c *gin.Context) bool {
+	userValue, exists := c.Get("user")
+	if !exists {
+		return false
+	}
+
+	user, ok := userValue.(*models.User)
+	if !ok || user == nil {
+		return false
+	}
+
+	for _, role := range user.Roles {
+		if role.Name == "admin" || role.Name == "root" {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *ClassHandler) GetClassProgress(c *gin.Context) {

--- a/backapp/tests/handler/class_handler_test.go
+++ b/backapp/tests/handler/class_handler_test.go
@@ -32,11 +32,13 @@ func TestClassHandler_GetClassScores(t *testing.T) {
 		}
 
 		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockEventRepo.On("GetEventByID", 1).Return(&models.Event{ID: 1, HideScores: false}, nil).Once()
 		mockClassRepo.On("GetClassScoresByEvent", 1).Return(expectedScores, nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/api/scores/class", nil)
+		c.Set("user", &models.User{ID: "user-1", Roles: []models.Role{{Name: "student"}}})
 
 		h.GetClassScores(c)
 
@@ -63,11 +65,13 @@ func TestClassHandler_GetClassScores(t *testing.T) {
 			{ID: 1, ClassName: "Class A", Season: "spring", TotalPointsCurrentEvent: 100, RankCurrentEvent: 1},
 		}
 
+		mockEventRepo.On("GetEventByID", 2).Return(&models.Event{ID: 2, HideScores: false}, nil).Once()
 		mockClassRepo.On("GetClassScoresByEvent", 2).Return(expectedScores, nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/api/scores/class?event_id=2", nil)
+		c.Set("user", &models.User{ID: "user-1", Roles: []models.Role{{Name: "student"}}})
 
 		h.GetClassScores(c)
 
@@ -80,6 +84,7 @@ func TestClassHandler_GetClassScores(t *testing.T) {
 
 		mockClassRepo.AssertExpectations(t)
 		mockEventRepo.AssertNotCalled(t, "GetActiveEvent")
+		mockEventRepo.AssertExpectations(t)
 	})
 
 	t.Run("no active event", func(t *testing.T) {
@@ -135,15 +140,80 @@ func TestClassHandler_GetClassScores(t *testing.T) {
 		h := handler.NewClassHandler(mockClassRepo, mockEventRepo, mockTeamRepo, mockTournamentRepo)
 
 		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockEventRepo.On("GetEventByID", 1).Return(&models.Event{ID: 1, HideScores: false}, nil).Once()
 		mockClassRepo.On("GetClassScoresByEvent", 1).Return(nil, errors.New("db error")).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/api/scores/class", nil)
+		c.Set("user", &models.User{ID: "user-1", Roles: []models.Role{{Name: "student"}}})
 
 		h.GetClassScores(c)
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+		mockClassRepo.AssertExpectations(t)
+		mockEventRepo.AssertExpectations(t)
+	})
+
+	t.Run("hidden scores returns forbidden for student", func(t *testing.T) {
+		mockClassRepo := new(MockClassRepository)
+		mockEventRepo := new(MockEventRepository)
+		mockTeamRepo := new(MockTeamRepository)
+		mockTournamentRepo := new(MockTournamentRepository)
+
+		h := handler.NewClassHandler(mockClassRepo, mockEventRepo, mockTeamRepo, mockTournamentRepo)
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockEventRepo.On("GetEventByID", 1).Return(&models.Event{ID: 1, HideScores: true}, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/scores/class", nil)
+		c.Set("user", &models.User{ID: "user-1", Roles: []models.Role{{Name: "student"}}})
+
+		h.GetClassScores(c)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "得点一覧は現在非表示です。", response["error"])
+
+		mockEventRepo.AssertExpectations(t)
+		mockClassRepo.AssertNotCalled(t, "GetClassScoresByEvent", mock.Anything)
+	})
+
+	t.Run("hidden scores visible for admin", func(t *testing.T) {
+		mockClassRepo := new(MockClassRepository)
+		mockEventRepo := new(MockEventRepository)
+		mockTeamRepo := new(MockTeamRepository)
+		mockTournamentRepo := new(MockTournamentRepository)
+
+		h := handler.NewClassHandler(mockClassRepo, mockEventRepo, mockTeamRepo, mockTournamentRepo)
+
+		expectedScores := []*models.ClassScore{
+			{ID: 1, ClassName: "Class A", Season: "spring", TotalPointsCurrentEvent: 100, RankCurrentEvent: 1},
+		}
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockEventRepo.On("GetEventByID", 1).Return(&models.Event{ID: 1, HideScores: true}, nil).Once()
+		mockClassRepo.On("GetClassScoresByEvent", 1).Return(expectedScores, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/scores/class", nil)
+		c.Set("user", &models.User{ID: "admin-1", Roles: []models.Role{{Name: "admin"}}})
+
+		h.GetClassScores(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var actualScores []*models.ClassScore
+		err := json.Unmarshal(w.Body.Bytes(), &actualScores)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedScores, actualScores)
 
 		mockClassRepo.AssertExpectations(t)
 		mockEventRepo.AssertExpectations(t)

--- a/frontapp/e2e/student-my-page-hidden-scores.spec.js
+++ b/frontapp/e2e/student-my-page-hidden-scores.spec.js
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+
+const mockBackendUrl = process.env.MOCK_BACKEND_URL ?? 'http://127.0.0.1:8081';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('マイページ 得点非表示 (student)', () => {
+  test.beforeEach(async ({ context, request }) => {
+    await request.post(`${mockBackendUrl}/__reset`);
+    await context.addCookies([{ name: 'session_token', value: 'test-session-token', domain: 'localhost', path: '/' }]);
+  });
+
+  test('得点非表示中の一般ユーザーには順位と得点を表示しない', async ({ page, request }) => {
+    await request.post(`${mockBackendUrl}/__set-user`, {
+      data: { user: 'student' }
+    });
+    await request.post(`${mockBackendUrl}/__set-active-event`, {
+      data: { event_id: 1, hide_scores: true }
+    });
+
+    await page.goto('/dashboard/student/my-page');
+
+    await expect(page.getByRole('heading', { name: 'マイページ' })).toBeVisible();
+    await expect(page.getByText('得点・順位は現在非表示です。')).toBeVisible();
+    await expect(page.getByText('公開されるまでお待ちください。')).toBeVisible();
+
+    await expect(page.getByText('クラス成績')).toHaveCount(0);
+    await expect(page.getByText('獲得ポイント内訳')).toHaveCount(0);
+    await expect(page.getByText('1位')).toHaveCount(0);
+    await expect(page.getByText('獲得 60 点')).toHaveCount(0);
+  });
+
+  test('得点非表示中でも管理者はマイページの得点を確認できる', async ({ page, request }) => {
+    await request.post(`${mockBackendUrl}/__set-user`, {
+      data: { user: 'admin' }
+    });
+    await request.post(`${mockBackendUrl}/__set-active-event`, {
+      data: { event_id: 1, hide_scores: true }
+    });
+
+    await page.goto('/dashboard/student/my-page');
+
+    await expect(page.getByRole('heading', { name: 'マイページ' })).toBeVisible();
+    await expect(page.getByText('得点・順位は現在非表示です。')).toHaveCount(0);
+    await expect(page.getByText('クラス成績')).toBeVisible();
+    await expect(page.getByText('2位')).toHaveCount(2);
+    await expect(page.getByText('獲得 50 点')).toBeVisible();
+  });
+});

--- a/frontapp/playwright.config.js
+++ b/frontapp/playwright.config.js
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const appPort = Number(process.env.PLAYWRIGHT_APP_PORT ?? 5000);
 const backendPort = Number(process.env.MOCK_BACKEND_PORT ?? 8081);
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
 
 export default defineConfig({
   testDir: './e2e',
@@ -13,6 +14,7 @@ export default defineConfig({
   use: {
     baseURL: `http://localhost:${appPort}`,
     trace: 'on-first-retry',
+    launchOptions: chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : undefined
   },
   projects: [
     {

--- a/frontapp/scripts/mock-backend.js
+++ b/frontapp/scripts/mock-backend.js
@@ -12,6 +12,30 @@ const rootUser = {
   roles: [{ name: 'root' }]
 };
 
+const studentUser = {
+  id: 'user-1',
+  email: 'student1@sendai-nct.jp',
+  display_name: '山田太郎',
+  class_id: 1,
+  is_profile_complete: true,
+  roles: [
+    { id: 1, name: 'student' },
+    { id: 2, name: '1A_rep' },
+    { id: 4, name: 'judge' }
+  ]
+};
+
+const adminUser = {
+  id: 'user-2',
+  email: 'admin1@sendai-nct.jp',
+  display_name: '運営花子',
+  class_id: 2,
+  is_profile_complete: true,
+  roles: [
+    { id: 3, name: 'admin' }
+  ]
+};
+
 const defaultEvents = () => ([
   {
     id: 1,
@@ -162,6 +186,7 @@ let notifications = [
     created_at: '2025-04-01T09:00:00Z'
   }
 ];
+let currentUser = rootUser;
 let classes = [
   { id: 1, name: '1A', student_count: 40 },
   { id: 2, name: '1B', student_count: 38 }
@@ -360,13 +385,39 @@ createServer(async (req, res) => {
     rainyModeSettings = [];
     qrCodeSequence = 0;
     qrCodeActiveTokens = new Map();
+    currentUser = rootUser;
     sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  if (url.pathname === '/__set-user' && req.method === 'POST') {
+    const body = await readJson(req);
+    if (body.user === 'student') {
+      currentUser = studentUser;
+    } else if (body.user === 'admin') {
+      currentUser = adminUser;
+    } else {
+      currentUser = rootUser;
+    }
+    sendJson(res, 200, { user: currentUser });
+    return;
+  }
+
+  if (url.pathname === '/__set-active-event' && req.method === 'POST') {
+    const body = await readJson(req);
+    const eventId = Number(body.event_id ?? 1);
+    events = events.map((event) => ({
+      ...event,
+      status: event.id === eventId ? 'active' : event.status === 'active' ? 'upcoming' : event.status,
+      hide_scores: event.id === eventId ? Boolean(body.hide_scores) : event.hide_scores
+    }));
+    sendJson(res, 200, { event: events.find((event) => event.id === eventId) ?? null });
     return;
   }
 
   if (url.pathname === '/api/auth/user' && req.method === 'GET') {
     if (getSessionToken(req) === 'test-session-token') {
-      sendJson(res, 200, rootUser);
+      sendJson(res, 200, currentUser);
       return;
     }
 
@@ -456,16 +507,26 @@ createServer(async (req, res) => {
   if (url.pathname === '/api/scores/class' && req.method === 'GET') {
     sendJson(res, 200, [
       {
+        class_id: 1,
         class_name: '1A',
+        season: 'spring',
+        rank_current_event: 1,
         rank_overall: 1,
         total_points_overall: 120,
-        total_points_current_event: 60
+        total_points_current_event: 60,
+        attendance_points: 10,
+        noon_game_points: 20
       },
       {
+        class_id: 2,
         class_name: '1B',
+        season: 'spring',
+        rank_current_event: 2,
         rank_overall: 2,
         total_points_overall: 100,
-        total_points_current_event: 50
+        total_points_current_event: 50,
+        attendance_points: 8,
+        noon_game_points: 12
       }
     ]);
     return;
@@ -481,7 +542,8 @@ createServer(async (req, res) => {
             event_id: activeEvent.id,
             event_name: activeEvent.name,
             id: activeEvent.id,
-            name: activeEvent.name
+            name: activeEvent.name,
+            hide_scores: activeEvent.hide_scores
           }
         : null
     );

--- a/frontapp/src/routes/dashboard/student/my-page/+page.server.js
+++ b/frontapp/src/routes/dashboard/student/my-page/+page.server.js
@@ -3,6 +3,9 @@ const BACKEND_URL = env.BACKEND_URL;
 
 const toNumber = (value) => (typeof value === 'number' && !Number.isNaN(value) ? value : 0);
 
+const canViewHiddenScores = (user) =>
+	user?.roles?.some((role) => role?.name === 'admin' || role?.name === 'root') ?? false;
+
 const toDateValue = (value) => {
 	if (!value) return Number.POSITIVE_INFINITY;
 	const date = new Date(String(value).replace(' ', 'T'));
@@ -253,10 +256,46 @@ export const load = async ({ fetch, locals, request }) => {
 			headers.Authorization = authHeader;
 		}
 
+		let activeEventId = null;
+		const activeEventResponse = await fetch(`${BACKEND_URL}/api/events/active`, { headers });
+		if (activeEventResponse.ok) {
+			const activeEventPayload = await activeEventResponse.json();
+			activeEventId = activeEventPayload?.event_id;
+
+			if (activeEventPayload?.hide_scores && !canViewHiddenScores(user)) {
+				return {
+					user,
+					myClassScore: null,
+					scoresHidden: true,
+					scoreItems: [],
+					categoryBreakdown: [],
+					pointHighlights: [],
+					sportSections: [],
+					assignedSports: [],
+					upcomingMatches: [],
+					scoreHistory: []
+				};
+			}
+		}
+
 		const scoreResponse = await fetch(`${BACKEND_URL}/api/scores/class`, {
 			headers
 		});
 		if (!scoreResponse.ok) {
+			if (scoreResponse.status === 403) {
+				return {
+					user,
+					myClassScore: null,
+					scoresHidden: true,
+					scoreItems: [],
+					categoryBreakdown: [],
+					pointHighlights: [],
+					sportSections: [],
+					assignedSports: [],
+					upcomingMatches: [],
+					scoreHistory: []
+				};
+			}
 			throw new Error('クラスの得点一覧の取得に失敗しました。');
 		}
 		const classScores = await scoreResponse.json();
@@ -284,37 +323,37 @@ export const load = async ({ fetch, locals, request }) => {
 
 		let upcomingMatches = [];
 		let assignedSports = [];
-		const activeEventResponse = await fetch(`${BACKEND_URL}/api/events/active`, { headers });
-		if (activeEventResponse.ok) {
-			const activeEventPayload = await activeEventResponse.json();
-			const activeEventId = activeEventPayload?.event_id;
+		if (activeEventId) {
+			const [teamsResponse, tournamentsResponse, noonResponse] = await Promise.all([
+				fetch(`${BACKEND_URL}/api/qrcode/teams`, { headers }),
+				fetch(`${BACKEND_URL}/api/student/events/${activeEventId}/tournaments`, { headers }),
+				fetch(`${BACKEND_URL}/api/student/events/${activeEventId}/noon-game/session`, { headers })
+			]);
 
-			if (activeEventId) {
-				const [teamsResponse, tournamentsResponse, noonResponse] = await Promise.all([
-					fetch(`${BACKEND_URL}/api/qrcode/teams`, { headers }),
-					fetch(`${BACKEND_URL}/api/student/events/${activeEventId}/tournaments`, { headers }),
-					fetch(`${BACKEND_URL}/api/student/events/${activeEventId}/noon-game/session`, { headers })
-				]);
+			const teams = teamsResponse.ok ? await teamsResponse.json() : [];
+			const currentEventTeams = Array.isArray(teams)
+				? teams.filter((team) => Number(team?.event_id) === Number(activeEventId))
+				: [];
+			assignedSports = buildAssignedSports(currentEventTeams);
 
-				const teams = teamsResponse.ok ? await teamsResponse.json() : [];
-				const currentEventTeams = Array.isArray(teams)
-					? teams.filter((team) => Number(team?.event_id) === Number(activeEventId))
-					: [];
-				assignedSports = buildAssignedSports(currentEventTeams);
+			const tournamentMatches = tournamentsResponse.ok
+				? buildTournamentUpcomingMatches(await tournamentsResponse.json(), currentEventTeams)
+				: [];
 
-				const tournamentMatches = tournamentsResponse.ok
-					? buildTournamentUpcomingMatches(await tournamentsResponse.json(), currentEventTeams)
-					: [];
+			const noonMatches = noonResponse.ok
+				? buildNoonUpcomingMatches(await noonResponse.json(), user.class_id)
+				: [];
 
-				const noonMatches = noonResponse.ok
-					? buildNoonUpcomingMatches(await noonResponse.json(), user.class_id)
-					: [];
-
-				upcomingMatches = [...tournamentMatches, ...noonMatches]
-					.filter((match) => match.start_time || match.opponent_name || match.location)
-					.sort((left, right) => left.sort_value - right.sort_value)
-					.map(({ sort_value, status, ...match }) => match);
-			}
+			upcomingMatches = [...tournamentMatches, ...noonMatches]
+				.filter((match) => match.start_time || match.opponent_name || match.location)
+				.sort((left, right) => left.sort_value - right.sort_value)
+				.map((match) => ({
+					id: match.id,
+					start_time: match.start_time,
+					sport_name: match.sport_name,
+					opponent_name: match.opponent_name,
+					location: match.location
+				}));
 		}
 
 		return {

--- a/frontapp/src/routes/dashboard/student/my-page/+page.svelte
+++ b/frontapp/src/routes/dashboard/student/my-page/+page.svelte
@@ -9,6 +9,7 @@
 	let user = $derived(data.user);
 	let myClassScore = $derived(data.myClassScore);
 	let errorMessage = $derived(data.error);
+	let scoresHidden = $derived(Boolean(data.scoresHidden));
 	let upcomingMatches = $derived(data.upcomingMatches || []);
 	let assignedSports = $derived(data.assignedSports || []);
 	let scoreItems = $derived(data.scoreItems || []);
@@ -158,7 +159,28 @@
 		<p class="text-base text-gray-600">クラスの現状とポイント内訳をまとめて確認できます</p>
 	</div>
 
-	{#if errorMessage && !hasScore}
+	{#if scoresHidden}
+		<div class="bg-amber-50 border-l-4 border-amber-500 rounded-lg p-4 flex items-start gap-3 shadow-sm">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				class="h-6 w-6 text-amber-500 flex-shrink-0 mt-0.5"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
+				/>
+			</svg>
+			<div class="space-y-1">
+				<p class="font-semibold text-amber-900">得点・順位は現在非表示です。</p>
+				<p class="text-sm text-amber-800">公開されるまでお待ちください。</p>
+			</div>
+		</div>
+	{:else if errorMessage && !hasScore}
 		<div class="bg-red-50 border-l-4 border-red-500 rounded-lg p-4 flex items-start gap-3 shadow-sm">
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/frontapp/src/routes/dashboard/student/my-page/my-page.server.spec.js
+++ b/frontapp/src/routes/dashboard/student/my-page/my-page.server.spec.js
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { load } from './+page.server.js';
+
+const makeRequest = () =>
+	new Request('http://localhost/dashboard/student/my-page', {
+		headers: {
+			cookie: 'session=student-session',
+			Authorization: 'Bearer test-token'
+		}
+	});
+
+const student = {
+	id: 'student-1',
+	class_id: 10,
+	roles: [{ name: 'student' }]
+};
+
+const admin = {
+	id: 'admin-1',
+	class_id: 10,
+	roles: [{ name: 'admin' }]
+};
+
+const hasPath = (url, path) => String(url).endsWith(path);
+
+describe('student my-page server load', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('得点非表示中の一般ユーザーには得点APIを呼ばず非表示状態を返す', async () => {
+		expect.assertions(5);
+
+		const fetchMock = vi.fn((url) => {
+			if (hasPath(url, '/api/events/active')) {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ event_id: 1, hide_scores: true })
+				});
+			}
+
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		});
+
+		const result = await load({
+			fetch: fetchMock,
+			locals: { user: student },
+			request: makeRequest()
+		});
+
+		expect(result.scoresHidden).toBe(true);
+		expect(result.myClassScore).toBeNull();
+		expect(result.scoreItems).toEqual([]);
+		expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/api\/events\/active$/), expect.any(Object));
+		expect(fetchMock).not.toHaveBeenCalledWith(expect.stringMatching(/\/api\/scores\/class$/), expect.any(Object));
+	});
+
+	it('得点APIが403を返した場合も非表示状態として扱う', async () => {
+		expect.assertions(4);
+
+		const fetchMock = vi.fn((url) => {
+			if (hasPath(url, '/api/events/active')) {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ event_id: 1, hide_scores: false })
+				});
+			}
+
+			if (hasPath(url, '/api/scores/class')) {
+				return Promise.resolve({
+					ok: false,
+					status: 403,
+					json: () => Promise.resolve({ error: '得点一覧は現在非表示です。' })
+				});
+			}
+
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		});
+
+		const result = await load({
+			fetch: fetchMock,
+			locals: { user: student },
+			request: makeRequest()
+		});
+
+		expect(result.scoresHidden).toBe(true);
+		expect(result.myClassScore).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/api\/events\/active$/), expect.any(Object));
+		expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/api\/scores\/class$/), expect.any(Object));
+	});
+
+	it('得点非表示中でも管理者は得点情報を取得できる', async () => {
+		expect.assertions(4);
+
+		const fetchMock = vi.fn((url) => {
+			if (hasPath(url, '/api/events/active')) {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ event_id: 1, hide_scores: true })
+				});
+			}
+
+			if (hasPath(url, '/api/scores/class')) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve([
+							{
+								class_id: 10,
+								class_name: '1A',
+								season: 'spring',
+								rank_current_event: 2,
+								rank_overall: 3,
+								total_points_current_event: 80,
+								total_points_overall: 120
+							}
+						])
+				});
+			}
+
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		});
+
+		const result = await load({
+			fetch: fetchMock,
+			locals: { user: admin },
+			request: makeRequest()
+		});
+
+		expect(result.scoresHidden).toBeUndefined();
+		expect(result.myClassScore.primaryRank).toBe(2);
+		expect(result.myClassScore.primaryPoints).toBe(80);
+		expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/api\/scores\/class$/), expect.any(Object));
+	});
+});


### PR DESCRIPTION
## 概要

Issue #159 の対応です。
得点非表示設定が有効な状態でも、マイページから自分の順位や得点が分かってしまう問題を修正しました。

## 原因

マイページが `/api/scores/class` からクラス得点一覧を取得しており、得点非表示設定を確認せずに自分のクラスの順位・点数・内訳を表示していました。
また、API側でも `/api/scores/class` が一般ユーザーに対して得点非表示設定を見ていなかったため、フロント以外からも得点情報を取得できる状態でした。

## 変更内容

- `/api/scores/class` で、対象大会の `hide_scores` が有効な場合は一般ユーザーに `403` を返すように変更
- `admin` / `root` は得点非表示中でも確認できるように維持
- マイページで得点非表示中は順位・得点カードを出さず、「得点・順位は現在非表示です。」という案内を表示
- マイページのserver loadにユニットテストを追加
- student/adminそれぞれのマイページ表示を確認するE2Eテストを追加
- E2E用モックバックエンドでユーザー種別と `hide_scores` を切り替えられるように調整

## 確認したこと

- `go test ./...`
- `npm run lint`
- `npm run test:unit -- --project server src/routes/dashboard/student/my-page/my-page.server.spec.js --run`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome npm run test:e2e -- student-my-page-hidden-scores.spec.js`

## 影響

- 得点非表示中の一般ユーザーは、マイページから順位・得点・得点内訳を確認できなくなります。
- 管理者権限を持つユーザーは、これまで通り得点確認ができます。
