### PR TITLE
#195 DBダンプとアップロードファイルダンプを出力できるようにする

### DIFF
--- a/backapp/internal/handler/system_handler.go
+++ b/backapp/internal/handler/system_handler.go
@@ -1,10 +1,14 @@
 package handler
 
 import (
+	"archive/zip"
 	"backapp/internal/config"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -37,7 +41,7 @@ func (h *SystemHandler) ExportDBDump(c *gin.Context) {
 	)
 
 	// Pass password via environment variable
-	cmd.Env = append(cmd.Env, fmt.Sprintf("MYSQL_PWD=%s", h.cfg.DBPassword))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("MYSQL_PWD=%s", h.cfg.DBPassword))
 
 	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=database_dump_%s.sql", time.Now().Format("20060102_150405")))
 	c.Writer.Header().Set("Content-Type", "application/sql")
@@ -47,6 +51,78 @@ func (h *SystemHandler) ExportDBDump(c *gin.Context) {
 	// Print stderr if any error occurs
 	if err := cmd.Run(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate database dump"})
+		return
+	}
+}
+
+func (h *SystemHandler) ExportUploadsDump(c *gin.Context) {
+	uploadsDir := "./uploads"
+
+	stat, err := os.Stat(uploadsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Uploads directory not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to access uploads directory"})
+		return
+	}
+	if !stat.IsDir() {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Uploads path is not a directory"})
+		return
+	}
+
+	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=uploads_dump_%s.zip", time.Now().Format("20060102_150405")))
+	c.Writer.Header().Set("Content-Type", "application/zip")
+
+	zipWriter := zip.NewWriter(c.Writer)
+	defer zipWriter.Close()
+
+	if err := filepath.WalkDir(uploadsDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		relativePath, err := filepath.Rel(uploadsDir, path)
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(relativePath)
+		header.Method = zip.Deflate
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		if _, err = io.Copy(writer, file); err != nil {
+			file.Close()
+			return err
+		}
+		return file.Close()
+	}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate uploads dump"})
 		return
 	}
 }

--- a/backapp/internal/router/router.go
+++ b/backapp/internal/router/router.go
@@ -290,6 +290,10 @@ func SetupRouter(db *sql.DB, cfg *config.Config, hubManager *websocket.HubManage
 			{
 				rootDB.GET("/export", systemHandler.ExportDBDump)
 			}
+			rootUploads := root.Group("/uploads")
+			{
+				rootUploads.GET("/export", systemHandler.ExportUploadsDump)
+			}
 
 			rootNoon := root.Group("/noon-game")
 			{

--- a/backapp/tests/handler/system_handler_test.go
+++ b/backapp/tests/handler/system_handler_test.go
@@ -1,10 +1,15 @@
 package handler_test
 
 import (
+	"archive/zip"
 	"backapp/internal/config"
 	"backapp/internal/handler"
+	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -12,19 +17,32 @@ import (
 )
 
 func TestExportDBDump(t *testing.T) {
-	// Set gin to test mode
 	gin.SetMode(gin.TestMode)
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "mysqldump.args")
+	passwordFile := filepath.Join(tempDir, "mysqldump.password")
+	fakeBinDir := filepath.Join(tempDir, "bin")
 
-	// Since mysqldump is not available in the testing environment natively (often),
-	// we will just verify the endpoint configuration and expected headers,
-	// and accept that the actual command execution might fail with a 500 error in a pure unit test environment without MySQL client.
+	assert.NoError(t, os.MkdirAll(fakeBinDir, 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeBinDir, "mysqldump"), []byte(`#!/bin/sh
+printf '%s\n' "$@" > "$MYSQLDUMP_ARGS_FILE"
+printf '%s' "$MYSQL_PWD" > "$MYSQLDUMP_PASSWORD_FILE"
+cat <<'SQL'
+CREATE TABLE users (id int);
+INSERT INTO users VALUES (1);
+SQL
+`), 0o755))
+
+	t.Setenv("MYSQLDUMP_ARGS_FILE", argsFile)
+	t.Setenv("MYSQLDUMP_PASSWORD_FILE", passwordFile)
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	cfg := &config.Config{
-		DBHost:     "localhost",
-		DBPort:     "3306",
-		DBUser:     "test_user",
+		DBHost:     "127.0.0.1",
+		DBPort:     "3307",
+		DBUser:     "dump_user",
 		DBPassword: "test_password",
-		DBName:     "test_db",
+		DBName:     "sportease",
 	}
 
 	systemHandler := handler.NewSystemHandler(cfg)
@@ -37,16 +55,129 @@ func TestExportDBDump(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	// In a complete integration test environment, it would return 200 OK.
-	// But in a local unit test where `mysqldump` command is likely missing, it will return 500 Internal Server Error.
-	// Therefore, we check that it's either 200 or 500 (due to missing mysqldump).
-	assert.True(t, w.Code == http.StatusOK || w.Code == http.StatusInternalServerError, "Expected 200 OK or 500 Internal Server Error")
+	assert.Equal(t, http.StatusOK, w.Code)
 
-	// Verify headers are correctly set
 	contentDisposition := w.Header().Get("Content-Disposition")
 	assert.Contains(t, contentDisposition, "attachment; filename=database_dump_")
 	assert.Contains(t, contentDisposition, ".sql")
 
 	contentType := w.Header().Get("Content-Type")
 	assert.Equal(t, "application/sql", contentType)
+
+	assert.Contains(t, w.Body.String(), "CREATE TABLE users")
+	assert.Contains(t, w.Body.String(), "INSERT INTO users VALUES")
+
+	argsBytes, err := os.ReadFile(argsFile)
+	assert.NoError(t, err)
+	args := strings.Fields(string(argsBytes))
+	assert.Equal(t, []string{
+		"-h", "127.0.0.1",
+		"-P", "3307",
+		"-u", "dump_user",
+		"--default-character-set=utf8mb4",
+		"--single-transaction",
+		"--routines",
+		"--triggers",
+		"sportease",
+	}, args)
+	assert.NotContains(t, args, "--no-data")
+	assert.NotContains(t, args, "--no-create-info")
+
+	passwordBytes, err := os.ReadFile(passwordFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "test_password", string(passwordBytes))
+}
+
+func TestExportDBDumpCommandFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tempDir := t.TempDir()
+	fakeBinDir := filepath.Join(tempDir, "bin")
+
+	assert.NoError(t, os.MkdirAll(fakeBinDir, 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeBinDir, "mysqldump"), []byte(`#!/bin/sh
+exit 7
+`), 0o755))
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	systemHandler := handler.NewSystemHandler(&config.Config{
+		DBHost:     "127.0.0.1",
+		DBPort:     "3307",
+		DBUser:     "dump_user",
+		DBPassword: "test_password",
+		DBName:     "sportease",
+	})
+
+	router := gin.Default()
+	router.GET("/api/root/db/export", systemHandler.ExportDBDump)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/root/db/export", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to generate database dump")
+}
+
+func TestExportUploadsDump(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Chdir(t.TempDir())
+
+	assert.NoError(t, os.MkdirAll(filepath.Join("uploads", "pdfs"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join("uploads", "pdfs", "guide.pdf"), []byte("pdf-data"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join("uploads", "image.png"), []byte("image-data"), 0o644))
+
+	systemHandler := handler.NewSystemHandler(&config.Config{})
+
+	router := gin.Default()
+	router.GET("/api/root/uploads/export", systemHandler.ExportUploadsDump)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/root/uploads/export", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment; filename=uploads_dump_")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".zip")
+	assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
+
+	reader, err := zip.NewReader(bytes.NewReader(w.Body.Bytes()), int64(w.Body.Len()))
+	assert.NoError(t, err)
+
+	entries := make(map[string]string)
+	for _, file := range reader.File {
+		opened, err := file.Open()
+		assert.NoError(t, err)
+
+		body := new(bytes.Buffer)
+		_, err = body.ReadFrom(opened)
+		assert.NoError(t, err)
+		assert.NoError(t, opened.Close())
+
+		entries[file.Name] = body.String()
+	}
+
+	assert.Equal(t, map[string]string{
+		"image.png":      "image-data",
+		"pdfs/guide.pdf": "pdf-data",
+	}, entries)
+}
+
+func TestExportUploadsDumpMissingDirectory(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Chdir(t.TempDir())
+
+	systemHandler := handler.NewSystemHandler(&config.Config{})
+
+	router := gin.Default()
+	router.GET("/api/root/uploads/export", systemHandler.ExportUploadsDump)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/root/uploads/export", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "Uploads directory not found")
 }

--- a/frontapp/e2e/root-event-management.spec.js
+++ b/frontapp/e2e/root-event-management.spec.js
@@ -236,4 +236,14 @@ test.describe('大会情報登録・管理 (root)', () => {
 
     await dumpRequest;
   });
+
+  test('アップロードファイルダンプを出力できる', async ({ page }) => {
+    const dumpRequest = page.waitForRequest((request) => {
+      return request.url().endsWith('/api/root/uploads/export') && request.method() === 'GET';
+    });
+
+    await page.getByRole('button', { name: 'アップロードファイル出力' }).click();
+
+    await dumpRequest;
+  });
 });

--- a/frontapp/scripts/mock-backend.js
+++ b/frontapp/scripts/mock-backend.js
@@ -504,6 +504,14 @@ createServer(async (req, res) => {
     return;
   }
 
+  if (url.pathname === '/api/root/uploads/export' && req.method === 'GET') {
+    sendResponse(res, 200, 'mock zip', {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': 'attachment; filename="mock_uploads.zip"'
+    });
+    return;
+  }
+
   if (url.pathname === '/api/scores/class' && req.method === 'GET') {
     sendJson(res, 200, [
       {

--- a/frontapp/src/routes/dashboard/root/event-management/+page.svelte
+++ b/frontapp/src/routes/dashboard/root/event-management/+page.svelte
@@ -253,14 +253,44 @@
       alert(err.message);
     }
   }
+
+  async function downloadUploadsDump() {
+    try {
+      const resp = await fetch('/api/root/uploads/export');
+      if (!resp.ok) {
+        const errorData = await resp.json().catch(() => null);
+        throw new Error((errorData && errorData.error) || 'アップロードファイルダンプのダウンロードに失敗しました');
+      }
+
+      const blob = await resp.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const contentDisposition = resp.headers.get('Content-Disposition');
+      let filename = 'uploads_dump.zip';
+      if (contentDisposition && contentDisposition.includes('filename=')) {
+        filename = contentDisposition.split('filename=')[1].replace(/"/g, '');
+      }
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      alert(err.message);
+    }
+  }
 </script>
 
 <div class="container mx-auto p-4">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold">大会情報登録・管理</h1>
-    <div class="flex space-x-2">
+    <div class="flex flex-wrap gap-2">
       <button onclick={downloadDBDump} class="btn btn-secondary bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700">
         DBダンプ出力
+      </button>
+      <button onclick={downloadUploadsDump} class="btn btn-secondary bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700">
+        アップロードファイル出力
       </button>
       <button onclick={openCreateModal} class="btn btn-primary bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700">
         新規作成

--- a/frontapp/src/routes/dashboard/root/event-management/event-management.svelte.spec.js
+++ b/frontapp/src/routes/dashboard/root/event-management/event-management.svelte.spec.js
@@ -100,6 +100,16 @@ describe('Event Management Page', () => {
         });
       }
 
+      if (url === '/api/root/uploads/export') {
+        return Promise.resolve({
+          ok: true,
+          blob: () => Promise.resolve(new Blob(['mock zip'], { type: 'application/zip' })),
+          headers: {
+            get: (name) => name === 'Content-Disposition' ? 'attachment; filename="mock_uploads.zip"' : null
+          }
+        });
+      }
+
       if (typeof url === 'string' && url.startsWith('/api/scores/class?')) {
         return Promise.resolve({
           ok: true,
@@ -395,6 +405,22 @@ describe('Event Management Page', () => {
       expect(anchorClickMock).toHaveBeenCalled();
       const anchor = document.createElement.mock.results.find((result) => result.value?.download === 'mock_dump.sql')?.value;
       expect(anchor?.download).toBe('mock_dump.sql');
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-export');
+    });
+  });
+
+  it('アップロードファイルダンプを出力できること', async () => {
+    render(Page);
+
+    await page.getByRole('button', { name: 'アップロードファイル出力' }).click();
+
+    await vi.waitFor(() => {
+      const dumpCall = fetchMock.mock.calls.find(([url]) => url === '/api/root/uploads/export');
+      expect(dumpCall).toBeTruthy();
+      expect(createObjectURLMock).toHaveBeenCalled();
+      expect(anchorClickMock).toHaveBeenCalled();
+      const anchor = document.createElement.mock.results.find((result) => result.value?.download === 'mock_uploads.zip')?.value;
+      expect(anchor?.download).toBe('mock_uploads.zip');
       expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-export');
     });
   });

--- a/frontapp/vite.config.js
+++ b/frontapp/vite.config.js
@@ -4,6 +4,7 @@ import { playwright } from '@vitest/browser-playwright';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 const backendUrl = process.env.PUBLIC_BACKEND_URL || process.env.BACKEND_URL || 'http://localhost:8080';
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
@@ -28,7 +29,11 @@ export default defineConfig({
 					name: 'client',
 					browser: {
 						enabled: true,
-						provider: playwright(),
+						provider: playwright(
+							chromiumExecutablePath
+								? { launchOptions: { executablePath: chromiumExecutablePath } }
+								: undefined
+						),
 						instances: [{ browser: 'chromium' }],
 						headless: true
 					},


### PR DESCRIPTION
## 概要

Issue #195 の対応です。
引き継ぎ資料の「DBバックアップと画像・アップロードファイルバックアップを同じタイミングで取得する」運用に合わせて、root画面からDBダンプとアップロードファイルダンプを取得できるようにしました。

## 変更内容

- 既存のDBダンプ出力を、SQLダンプとしてより確実に検証できるようにテストを強化
- `/api/root/uploads/export` を追加
  - `./uploads` 配下のファイル・サブディレクトリをzip形式で出力
  - zipには `uploads` ディレクトリ自体ではなく、中身だけを格納
- 大会情報登録・管理画面に「アップロードファイル出力」ボタンを追加
- E2E用モックバックエンドにアップロードファイルダンプAPIを追加
- Vitest browserでもローカルChromeを指定できるように調整

## DBダンプについて

引き継ぎ資料では「SQLダンプ形式で取得する。テーブル定義とデータを含める」とされています。
現在の実装は `mysqldump <database>` を実行し、`--no-data` や `--no-create-info` を付けていないため、MySQL標準の挙動としてテーブル定義とデータの両方を含みます。

あわせて、以下をテストで検証するようにしました。

- `mysqldump` にDB接続情報とDB名が渡ること
- `MYSQL_PWD` でパスワードが渡ること
- 出力SQLに `CREATE TABLE` と `INSERT` が含まれること
- `--no-data` / `--no-create-info` が付いていないこと
- `mysqldump` 失敗時に500を返すこと

## 確認したこと

- `go test ./...`
- `npm run lint`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome npm run test:unit -- --project client src/routes/dashboard/root/event-management/event-management.svelte.spec.js --run`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome npm run test:e2e -- root-event-management.spec.js`

## 影響

- rootユーザーは大会情報登録・管理画面からDBダンプとアップロードファイルダンプを取得できます。
- 復旧処理は引き継ぎ資料どおり、アプリ内アップロードではなくSSH/Docker Compose経由で行う前提です。
