### PR TITLE
feat: 競技の割り当て時に「その他」およびカスタム「other:<name>」ロケーションの重複を許可し、関連するUIとテストを更新

### DIFF
--- a/backapp/internal/repository/sport_repository.go
+++ b/backapp/internal/repository/sport_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"strings"
 )
 
 // SportRepository defines the interface for sport and event_sport related database operations.
@@ -131,8 +132,8 @@ func (r *sportRepository) AssignSportToEvent(eventSport *models.EventSport) erro
 		return errors.New("この競技はすでにこの大会に割り当てられています。")
 	}
 
-	// Prevent duplicate locations, except for 'other'
-	if eventSport.Location != "other" {
+	// Prevent duplicate locations, except for 'other' and custom "other:<name>" locations.
+	if !isOtherLocation(eventSport.Location) {
 		query := "SELECT COUNT(*) FROM event_sports WHERE event_id = ? AND location = ?"
 		err := r.db.QueryRow(query, eventSport.EventID, eventSport.Location).Scan(&count)
 		if err != nil {
@@ -149,6 +150,10 @@ func (r *sportRepository) AssignSportToEvent(eventSport *models.EventSport) erro
 		log.Printf("Error inserting EventSport: %v", err)
 	}
 	return err
+}
+
+func isOtherLocation(location string) bool {
+	return location == "other" || strings.HasPrefix(location, "other:")
 }
 
 // DeleteSportFromEvent removes the assignment of a sport from an event.

--- a/backapp/tests/repository/sport_repository_test.go
+++ b/backapp/tests/repository/sport_repository_test.go
@@ -288,6 +288,24 @@ func TestSportRepository_AssignSportToEvent(t *testing.T) {
 		assert.NoError(t, repo.AssignSportToEvent(&esOther))
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
+
+	t.Run("custom other location allows duplicate location", func(t *testing.T) {
+		repo, mock, close := setupSport(t)
+		defer close()
+
+		esOther := *es
+		esOther.Location = "other:中庭ステージ"
+
+		mock.ExpectQuery(regexp.QuoteMeta(checkDupSportQ)).WithArgs(1, 3).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		// No location check for custom "other:<name>" locations.
+		mock.ExpectExec(regexp.QuoteMeta(insertQ)).
+			WithArgs(esOther.EventID, esOther.SportID, esOther.Description, esOther.Rules, esOther.RulesType, esOther.RulesPdfURL, esOther.Location, esOther.MinCapacity, esOther.MaxCapacity).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		assert.NoError(t, repo.AssignSportToEvent(&esOther))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 // ─── DeleteSportFromEvent ──────────────────────────────────────────────────

--- a/frontapp/src/routes/dashboard/root/sport-management/+page.svelte
+++ b/frontapp/src/routes/dashboard/root/sport-management/+page.svelte
@@ -14,6 +14,7 @@
         description: '',
         rules: '',
         location: 'other',
+        other_location: '',
         rules_type: 'markdown', // Add default rules_type
     });
 
@@ -32,7 +33,7 @@
     let usedLocations = $derived(eventSports
         ? eventSports
               .map(es => es.location)
-              .filter(loc => loc !== 'other' && loc !== 'noon_game')
+              .filter(loc => loc !== 'other' && !isOtherLocation(loc) && loc !== 'noon_game')
         : []);
 
     // この画面で扱うのは「通常競技」のみ（noon_game は別画面で管理）
@@ -168,8 +169,13 @@
             alert('割り当てる競技を選択してください。');
             return;
         }
+        if (newAssignment.location === 'other' && !newAssignment.other_location.trim()) {
+            alert('具体的な場所を入力してください。');
+            return;
+        }
 
         isAssigning = true; // 処理開始
+        const location = buildAssignmentLocation();
         
         try {
             // /api/admin/events/:id/sports は管理者権限が必要
@@ -177,8 +183,11 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    ...newAssignment,
                     sport_id: parseInt(newAssignment.sport_id, 10),
+                    description: newAssignment.description,
+                    rules: newAssignment.rules,
+                    location,
+                    rules_type: newAssignment.rules_type,
                 }),
             });
             if (!response.ok) {
@@ -195,6 +204,7 @@
                 description: '', 
                 rules: '', 
                 location: 'other',
+                other_location: '',
                 rules_type: 'markdown'
             };
             
@@ -240,6 +250,40 @@
     function getSportName(sportId) {
         const sport = allSports.find(s => s.id === sportId);
         return sport ? sport.name : '不明な競技';
+    }
+
+    function isOtherLocation(location) {
+        return typeof location === 'string' && location.startsWith('other:');
+    }
+
+    function buildAssignmentLocation() {
+        if (newAssignment.location !== 'other') {
+            return newAssignment.location;
+        }
+
+        return `other:${newAssignment.other_location.trim()}`;
+    }
+
+    function displayLocation(location) {
+        if (isOtherLocation(location)) {
+            return location.slice('other:'.length);
+        }
+
+        if (location === 'other') {
+            return 'その他';
+        }
+
+        return location;
+    }
+
+    function locationOptionLabel(location) {
+        const labels = {
+            gym1: 'gym1',
+            gym2: 'gym2',
+            ground: 'ground',
+            other: 'その他'
+        };
+        return labels[location] || location;
     }
 
     function startEditCapacity(eventId, sportId) {
@@ -375,11 +419,24 @@
                             <select id="location-select" bind:value={newAssignment.location} class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                                 {#each allLocations as loc (loc)}
                                     <option value={loc} disabled={usedLocations.includes(loc)}>
-                                        {loc} {usedLocations.includes(loc) ? '(使用中)' : ''}
+                                        {locationOptionLabel(loc)} {usedLocations.includes(loc) ? '(使用中)' : ''}
                                     </option>
                                 {/each}
                             </select>
                         </div>
+
+                        {#if newAssignment.location === 'other'}
+                            <div>
+                                <label for="other-location" class="block text-sm font-medium text-gray-700 mb-1">具体的な開催地</label>
+                                <input
+                                    id="other-location"
+                                    type="text"
+                                    bind:value={newAssignment.other_location}
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                    placeholder="例: 中庭ステージ、武道場、教室棟前"
+                                />
+                            </div>
+                        {/if}
                         
                         <!-- 概要 -->
                         <div>
@@ -422,7 +479,7 @@
                                     {#each visibleEventSports as es (es.sport_id)}
                                         <tr class="border-t hover:bg-gray-50">
                                             <td class="px-4 py-3 font-medium text-gray-900">{getSportName(es.sport_id)}</td>
-                                            <td class="px-4 py-3 text-gray-600">{es.location}</td>
+                                            <td class="px-4 py-3 text-gray-600">{displayLocation(es.location)}</td>
                                             <td class="px-4 py-3 text-gray-600 truncate max-w-xs">{es.description || '概要なし'}</td>
                                             <td class="px-4 py-3">
                                                 {#if editingCapacity && editingCapacity.event_id === es.event_id && editingCapacity.sport_id === es.sport_id}

--- a/frontapp/src/routes/dashboard/root/sport-management/sport-management.svelte.spec.js
+++ b/frontapp/src/routes/dashboard/root/sport-management/sport-management.svelte.spec.js
@@ -162,4 +162,38 @@ describe('Sport Management Page', () => {
     await expect.element(page.getByRole('cell', { name: 'バスケットボール' })).toBeInTheDocument();
     await expect.element(page.getByRole('cell', { name: 'gym1' })).toBeInTheDocument();
   });
+
+  it('場所がその他のとき具体的な場所を入力して表示できること', async () => {
+    render(Page);
+
+    await page.getByLabelText('割り当てる競技').selectOptions('2');
+    await page.getByLabelText('場所').selectOptions('other');
+    await page.getByLabelText('具体的な開催地').fill('中庭ステージ');
+    await page.getByRole('button', { name: '大会に競技を割り当てる' }).click();
+
+    const assignCall = fetchMock.mock.calls.find(([url, options]) => {
+      return url === '/api/admin/events/1/sports' && options?.method === 'POST';
+    });
+
+    expect(assignCall).toBeTruthy();
+    expect(JSON.parse(assignCall[1].body)).toEqual(expect.objectContaining({
+      sport_id: 2,
+      location: 'other:中庭ステージ'
+    }));
+    await expect.element(page.getByRole('cell', { name: '中庭ステージ' })).toBeInTheDocument();
+  });
+
+  it('場所がその他で具体的な場所が空のときは割り当てないこと', async () => {
+    render(Page);
+
+    await page.getByLabelText('割り当てる競技').selectOptions('2');
+    await page.getByLabelText('場所').selectOptions('other');
+    await page.getByRole('button', { name: '大会に競技を割り当てる' }).click();
+
+    expect(alertMock).toHaveBeenCalledWith('具体的な場所を入力してください。');
+    const assignCall = fetchMock.mock.calls.find(([url, options]) => {
+      return url === '/api/admin/events/1/sports' && options?.method === 'POST';
+    });
+    expect(assignCall).toBeFalsy();
+  });
 });

--- a/frontapp/src/routes/dashboard/student/sport-info/+page.svelte
+++ b/frontapp/src/routes/dashboard/student/sport-info/+page.svelte
@@ -47,6 +47,21 @@
     return sport?.sport_name || '不明な競技';
   }
 
+  function displayLocation(location) {
+    if (typeof location === 'string' && location.startsWith('other:')) {
+      return location.slice('other:'.length);
+    }
+
+    const labels = {
+      gym1: '第一体育館',
+      gym2: '第二体育館',
+      ground: 'グラウンド',
+      noon_game: 'グラウンド',
+      other: 'その他'
+    };
+    return labels[location] || location;
+  }
+
   function openRulesModal(sport) {
     // PDFの場合は別タブで開く
     if (sport.rules_type === 'pdf' && sport.rules_pdf_url) {
@@ -80,17 +95,7 @@
           {/if}
           <div class="mt-auto pt-4 border-t border-gray-200">
             <p class="text-gray-700 text-sm mb-2"><strong>場所:</strong>
-              {#if sport.location === 'gym1'}
-                <span>第一体育館</span>
-              {:else if sport.location === 'gym2'}
-                <span>第二体育館</span>
-              {:else if sport.location === 'ground'}
-                <span>グラウンド</span>
-              {:else if sport.location === 'noon_game'}
-                <span>グラウンド</span>
-              {:else}
-                <span>{sport.location}</span>
-              {/if}
+              <span>{displayLocation(sport.location)}</span>
             </p>
             <div>
               <button


### PR DESCRIPTION
feat: 競技設定で、「その他」を選択したときに、具体的な開催場所を入力できるようにしたい。
Fixes #194

## Summary

-

## Test

-

## DB Migration

- [ ] DB変更なし
- [ ] DB変更あり
  - migration file:
  - production apply required: yes / no
  - rollback SQL:
  - tested on local/staging DB:
