### PR TITLE
perf: クラススコア推移をSQL一括取得化する

### DIFF
--- a/backapp/internal/handler/statistics_handler.go
+++ b/backapp/internal/handler/statistics_handler.go
@@ -129,7 +129,11 @@ func (h *StatisticsHandler) GetClassScoreTrends(c *gin.Context) {
 
 	result := make(map[string][]*models.ClassScore)
 	for _, event := range events {
-		result[event.Name] = scoresByEventID[event.ID]
+		scores := scoresByEventID[event.ID]
+		if scores == nil {
+			scores = []*models.ClassScore{}
+		}
+		result[event.Name] = scores
 	}
 
 	c.JSON(http.StatusOK, result)

--- a/backapp/tests/handler/statistics_handler_test.go
+++ b/backapp/tests/handler/statistics_handler_test.go
@@ -98,6 +98,88 @@ func TestStatisticsHandler_GetClassScoreTrends(t *testing.T) {
 		mockClassRepo.AssertExpectations(t)
 	})
 
+	t.Run("複数イベントのスコアを一括取得しスコアなしイベントは空配列で返す", func(t *testing.T) {
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockTournRepo := new(MockTournamentRepository)
+
+		h := handler.NewStatisticsHandler(mockClassRepo, mockEventRepo, mockSportRepo, mockTournRepo)
+
+		activeEvent := &models.Event{
+			ID:         1,
+			Name:       "2026春季スポーツ大会",
+			HideScores: false,
+		}
+
+		events := []*models.Event{
+			{ID: 1, Name: "2026春季スポーツ大会"},
+			{ID: 2, Name: "2026秋季スポーツ大会"},
+		}
+
+		scores := []*models.ClassScore{
+			{ClassName: "1-A", TotalPointsCurrentEvent: 100},
+		}
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockEventRepo.On("GetEventByID", 1).Return(activeEvent, nil).Once()
+		mockEventRepo.On("GetAllEvents").Return(events, nil).Once()
+		mockClassRepo.On("GetClassScoresByEvents", []int{1, 2}).Return(map[int][]*models.ClassScore{1: scores}, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/admin/statistics/scores", nil)
+
+		h.GetClassScoreTrends(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string][]interface{}
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Len(t, resp["2026春季スポーツ大会"], 1)
+		assert.Empty(t, resp["2026秋季スポーツ大会"])
+
+		mockClassRepo.AssertNotCalled(t, "GetClassScoresByEvent", mock.Anything)
+		mockEventRepo.AssertExpectations(t)
+		mockClassRepo.AssertExpectations(t)
+	})
+
+	t.Run("イベントが0件でも空オブジェクトを返す", func(t *testing.T) {
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockTournRepo := new(MockTournamentRepository)
+
+		h := handler.NewStatisticsHandler(mockClassRepo, mockEventRepo, mockSportRepo, mockTournRepo)
+
+		activeEvent := &models.Event{
+			ID:         1,
+			Name:       "2026春季スポーツ大会",
+			HideScores: false,
+		}
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockEventRepo.On("GetEventByID", 1).Return(activeEvent, nil).Once()
+		mockEventRepo.On("GetAllEvents").Return([]*models.Event{}, nil).Once()
+		mockClassRepo.On("GetClassScoresByEvents", []int{}).Return(map[int][]*models.ClassScore{}, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/admin/statistics/scores", nil)
+
+		h.GetClassScoreTrends(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string][]interface{}
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Empty(t, resp)
+
+		mockClassRepo.AssertNotCalled(t, "GetClassScoresByEvent", mock.Anything)
+		mockEventRepo.AssertExpectations(t)
+		mockClassRepo.AssertExpectations(t)
+	})
+
 	t.Run("アクティブイベント取得エラー時に500を返す", func(t *testing.T) {
 		mockEventRepo := new(MockEventRepository)
 		mockClassRepo := new(MockClassRepository)


### PR DESCRIPTION
## 概要
- StatisticsHandler のクラス別スコア推移で、複数イベント分のスコアを一括取得する経路を補強
- スコアがないイベントを null ではなく空配列で返すようにして、既存レスポンス形式を安定化
- 複数イベント・スコアなしイベント・イベント0件の handler テストを追加

## 確認
- cd backapp && go test ./tests/handler -run TestStatisticsHandler_GetClassScoreTrends
- cd backapp && go test ./...

close #218