### PR TITLE
test: リアルタイム進捗のJOIN取得経路を検証する

### DIFF
--- a/backapp/tests/handler/statistics_handler_test.go
+++ b/backapp/tests/handler/statistics_handler_test.go
@@ -201,6 +201,118 @@ func TestStatisticsHandler_GetClassScoreTrends(t *testing.T) {
 	})
 }
 
+func TestStatisticsHandler_GetRealtimeEventProgress(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("JOIN取得用メソッドで競技名ごとの進行状況を返す", func(t *testing.T) {
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockTournRepo := new(MockTournamentRepository)
+
+		h := handler.NewStatisticsHandler(mockClassRepo, mockEventRepo, mockSportRepo, mockTournRepo)
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockTournRepo.On("GetTournamentSportNamesByEventID", 1).Return([]string{"サッカー", "バスケットボール"}, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/admin/statistics/progress", nil)
+
+		h.GetRealtimeEventProgress(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]string
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Equal(t, map[string]string{
+			"サッカー":     "進行中",
+			"バスケットボール": "進行中",
+		}, resp)
+
+		mockTournRepo.AssertNotCalled(t, "GetTournamentsByEventID", mock.Anything)
+		mockSportRepo.AssertNotCalled(t, "GetSportByID", mock.Anything)
+		mockEventRepo.AssertExpectations(t)
+		mockTournRepo.AssertExpectations(t)
+	})
+
+	t.Run("競技名が0件なら空オブジェクトを返す", func(t *testing.T) {
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockTournRepo := new(MockTournamentRepository)
+
+		h := handler.NewStatisticsHandler(mockClassRepo, mockEventRepo, mockSportRepo, mockTournRepo)
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockTournRepo.On("GetTournamentSportNamesByEventID", 1).Return([]string{}, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/admin/statistics/progress", nil)
+
+		h.GetRealtimeEventProgress(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]string
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Empty(t, resp)
+
+		mockTournRepo.AssertNotCalled(t, "GetTournamentsByEventID", mock.Anything)
+		mockSportRepo.AssertNotCalled(t, "GetSportByID", mock.Anything)
+		mockEventRepo.AssertExpectations(t)
+		mockTournRepo.AssertExpectations(t)
+	})
+
+	t.Run("アクティブイベント取得エラー時に500を返す", func(t *testing.T) {
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockTournRepo := new(MockTournamentRepository)
+
+		h := handler.NewStatisticsHandler(mockClassRepo, mockEventRepo, mockSportRepo, mockTournRepo)
+
+		mockEventRepo.On("GetActiveEvent").Return(0, assert.AnError).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/admin/statistics/progress", nil)
+
+		h.GetRealtimeEventProgress(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		mockTournRepo.AssertNotCalled(t, "GetTournamentSportNamesByEventID", mock.Anything)
+		mockTournRepo.AssertNotCalled(t, "GetTournamentsByEventID", mock.Anything)
+		mockSportRepo.AssertNotCalled(t, "GetSportByID", mock.Anything)
+		mockEventRepo.AssertExpectations(t)
+	})
+
+	t.Run("競技名取得エラー時に500を返す", func(t *testing.T) {
+		mockEventRepo := new(MockEventRepository)
+		mockClassRepo := new(MockClassRepository)
+		mockSportRepo := new(MockSportRepository)
+		mockTournRepo := new(MockTournamentRepository)
+
+		h := handler.NewStatisticsHandler(mockClassRepo, mockEventRepo, mockSportRepo, mockTournRepo)
+
+		mockEventRepo.On("GetActiveEvent").Return(1, nil).Once()
+		mockTournRepo.On("GetTournamentSportNamesByEventID", 1).Return(nil, assert.AnError).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/admin/statistics/progress", nil)
+
+		h.GetRealtimeEventProgress(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		mockTournRepo.AssertNotCalled(t, "GetTournamentsByEventID", mock.Anything)
+		mockSportRepo.AssertNotCalled(t, "GetSportByID", mock.Anything)
+		mockEventRepo.AssertExpectations(t)
+		mockTournRepo.AssertExpectations(t)
+	})
+}
+
 func TestStatisticsHandler_GetOverallAttendanceRate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backapp/tests/repository/tournament_repository_test.go
+++ b/backapp/tests/repository/tournament_repository_test.go
@@ -99,6 +99,58 @@ func TestTournamentRepository_GetTournamentsByEventID(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestTournamentRepository_GetTournamentSportNamesByEventID(t *testing.T) {
+	query := regexp.QuoteMeta(`
+		SELECT DISTINCT s.name
+		FROM tournaments t
+		JOIN sports s ON s.id = t.sport_id
+		WHERE t.event_id = ?
+		ORDER BY s.name
+	`)
+
+	t.Run("JOINで競技名だけを取得する", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer db.Close()
+
+		r := repository.NewTournamentRepository(db)
+
+		mock.ExpectQuery(query).
+			WithArgs(1).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("サッカー").
+				AddRow("バスケットボール"))
+
+		sportNames, err := r.GetTournamentSportNamesByEventID(1)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"サッカー", "バスケットボール"}, sportNames)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("対象トーナメントがない場合は空配列を返す", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer db.Close()
+
+		r := repository.NewTournamentRepository(db)
+
+		mock.ExpectQuery(query).
+			WithArgs(1).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}))
+
+		sportNames, err := r.GetTournamentSportNamesByEventID(1)
+
+		assert.NoError(t, err)
+		assert.Empty(t, sportNames)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestTournamentRepository_GetTournamentsByEventID_InferWinnerForTie(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
## 概要
- GetRealtimeEventProgress が JOIN 用の GetTournamentSportNamesByEventID を使うことを handler テストで固定
- 旧経路の GetTournamentsByEventID / GetSportByID が呼ばれないことを検証
- 競技0件・active event取得エラー・競技名取得エラーのレスポンスを検証
- GetTournamentSportNamesByEventID の JOIN クエリと空配列返却を repository テストで検証

## 確認
- cd backapp && go test ./tests/handler -run TestStatisticsHandler_GetRealtimeEventProgress
- cd backapp && go test ./tests/repository -run TestTournamentRepository_GetTournamentSportNamesByEventID
- cd backapp && go test ./...

close #219